### PR TITLE
Formatting rework

### DIFF
--- a/examples/ex_formatting.cpp
+++ b/examples/ex_formatting.cpp
@@ -45,7 +45,7 @@ int main() {
     // print records
     for (const auto& u: users) {
         std::cout << str("  |  ",
-            with(u.id, dec() | fmt_flag_t::padzeros | ff(widths[0])), "  |  ",
+            with(u.id, dec() | fmt::padzeros | ff(widths[0])), "  |  ",
             with(u.name, ff(widths[1], true)), "  |  ",
             with(u.score, fixed().precision(2) | ff(widths[2])), "  |  "
         ) << std::endl;

--- a/examples/ex_formatting.cpp
+++ b/examples/ex_formatting.cpp
@@ -15,9 +15,6 @@ struct User {
 };
 
 int main() {
-    using fmt::with;
-    using fmt::ff;
-
     std::vector<User> users {
         {1, "Alice", 85.0},
         {2, "Bob",   69.2},
@@ -48,9 +45,9 @@ int main() {
     // print records
     for (const auto& u: users) {
         std::cout << str("  |  ",
-            with(u.id, fmt::dec() | fmt::padzeros | ff(widths[0])), "  |  ",
+            with(u.id, dec() | fmt_flag_t::padzeros | ff(widths[0])), "  |  ",
             with(u.name, ff(widths[1], true)), "  |  ",
-            with(u.score, fmt::fixed().precision(2) | ff(widths[2])), "  |  "
+            with(u.score, fixed().precision(2) | ff(widths[2])), "  |  "
         ) << std::endl;
     }
     std::cout << sepline << std::endl;

--- a/examples/ex_formatting.cpp
+++ b/examples/ex_formatting.cpp
@@ -36,18 +36,18 @@ int main() {
     // print header
     std::cout << sepline << std::endl;
     std::cout << str("  |  ",
-        withf("id",    ff(widths[0], true)), "  |  ",
-        withf("name",  ff(widths[1], true)), "  |  ",
-        withf("score", ff(widths[2], true)), "  |  "
+        withf("id",    align_left(widths[0])), "  |  ",
+        withf("name",  align_left(widths[1])), "  |  ",
+        withf("score", align_left(widths[2])), "  |  "
     ) << std::endl;
     std::cout << sepline << std::endl;
 
     // print records
     for (const auto& u: users) {
         std::cout << str("  |  ",
-            withf(u.id, dec() | fmt::padzeros | ff(widths[0])), "  |  ",
-            withf(u.name, ff(widths[1], true)), "  |  ",
-            withf(u.score, fixed().precision(2) | ff(widths[2])), "  |  "
+            withf(u.id, dec() | fmt::padzeros | align_right(widths[0])), "  |  ",
+            withf(u.name, align_left(widths[1])), "  |  ",
+            withf(u.score, fixed().precision(2) | align_right(widths[2])), "  |  "
         ) << std::endl;
     }
     std::cout << sepline << std::endl;

--- a/examples/ex_formatting.cpp
+++ b/examples/ex_formatting.cpp
@@ -36,18 +36,18 @@ int main() {
     // print header
     std::cout << sepline << std::endl;
     std::cout << str("  |  ",
-        with("id",    ff(widths[0], true)), "  |  ",
-        with("name",  ff(widths[1], true)), "  |  ",
-        with("score", ff(widths[2], true)), "  |  "
+        withf("id",    ff(widths[0], true)), "  |  ",
+        withf("name",  ff(widths[1], true)), "  |  ",
+        withf("score", ff(widths[2], true)), "  |  "
     ) << std::endl;
     std::cout << sepline << std::endl;
 
     // print records
     for (const auto& u: users) {
         std::cout << str("  |  ",
-            with(u.id, dec() | fmt::padzeros | ff(widths[0])), "  |  ",
-            with(u.name, ff(widths[1], true)), "  |  ",
-            with(u.score, fixed().precision(2) | ff(widths[2])), "  |  "
+            withf(u.id, dec() | fmt::padzeros | ff(widths[0])), "  |  ",
+            withf(u.name, ff(widths[1], true)), "  |  ",
+            withf(u.score, fixed().precision(2) | ff(widths[2])), "  |  "
         ) << std::endl;
     }
     std::cout << sepline << std::endl;

--- a/examples/ex_formatting.cpp
+++ b/examples/ex_formatting.cpp
@@ -16,6 +16,7 @@ struct User {
 
 int main() {
     using fmt::with;
+    using fmt::ff;
 
     std::vector<User> users {
         {1, "Alice", 85.0},
@@ -38,18 +39,18 @@ int main() {
     // print header
     std::cout << sepline << std::endl;
     std::cout << str("  |  ",
-        with("id",    widths[0], true), "  |  ",
-        with("name",  widths[1], true), "  |  ",
-        with("score", widths[2], true), "  |  "
+        with("id",    ff(widths[0], true)), "  |  ",
+        with("name",  ff(widths[1], true)), "  |  ",
+        with("score", ff(widths[2], true)), "  |  "
     ) << std::endl;
     std::cout << sepline << std::endl;
 
     // print records
     for (const auto& u: users) {
         std::cout << str("  |  ",
-            with(u.id, fmt::dec() | fmt::padzeros, widths[0]), "  |  ",
-            with(u.name, widths[1], true), "  |  ",
-            with(u.score, fmt::fixed().precision(2), widths[2]), "  |  "
+            with(u.id, fmt::dec() | fmt::padzeros | ff(widths[0])), "  |  ",
+            with(u.name, ff(widths[1], true)), "  |  ",
+            with(u.score, fmt::fixed().precision(2) | ff(widths[2])), "  |  "
         ) << std::endl;
     }
     std::cout << sepline << std::endl;

--- a/examples/ex_newformatter.cpp
+++ b/examples/ex_newformatter.cpp
@@ -18,53 +18,36 @@ struct Triplet {
 //
 // The implementation can build on top of string_builder
 //
-
-class TripletFormatter {
+class TripletFormatter : public clue::fmt::formatter_base<TripletFormatter> {
 public:
-    size_t max_formatted_length(const Triplet& t) const noexcept {
-        using namespace clue::fmt;
-        size_t m1 = ndigits(t.v1, 10);
-        size_t m2 = ndigits(t.v2, 10);
-        size_t m3 = ndigits(t.v3, 10);
-        // note: strlen("(, , )") = 6
-        return m1 + m2 + m3 + 6;
-    }
-
     template<typename charT>
-    size_t formatted_write(const Triplet& t, charT *buf, size_t buf_len) const {
-        clue::basic_ref_string_builder<charT> s(buf, buf_len);
-        s << '('
-          << t.v1 << ", "
-          << t.v2 << ", "
-          << t.v3 << ')';
-        buf[s.size()] = '\0';
-        return s.size();
-    }
-
-    // Implementing the formatting with width & adjustment can be tedious,
-    // one can resort to the provided implementation helper, such as
-    //
-    //  'formatted_write_known_length'
-    //      or
-    //  'formatted_write_unknown_length'
-    //
-    // to simplify the implementation
-    //
-    template<typename charT>
-    size_t formatted_write(const Triplet& t, size_t width, bool leftjust,
-                           charT *buf, size_t buf_len) const {
-        size_t n = max_formatted_length(t);
-        return clue::fmt::formatted_write_known_length(
-            *this, t, n, width, leftjust, buf, buf_len);
+    size_t operator() (const Triplet& t, charT *buf, size_t buf_len) const {
+        if (buf) {
+            // write formatted string to the given buffer,
+            // and return the number of written characters
+            // (excluding the null terminator)
+            clue::basic_ref_string_builder<charT> s(buf, buf_len);
+            s << '('
+              << t.v1 << ", "
+              << t.v2 << ", "
+              << t.v3 << ')';
+            buf[s.size()] = '\0';
+            return s.size();
+        } else {
+            // compute the length of the formatted string
+            using namespace clue::fmt;
+            size_t m1 = ndigits(t.v1, 10);
+            size_t m2 = ndigits(t.v2, 10);
+            size_t m3 = ndigits(t.v3, 10);
+            return m1 + m2 + m3 + 6;
+        }
     }
 };
-
 
 // set TripletFormatter as default for Triplet
 CLUE_DEFAULT_FORMATTER(const Triplet&, TripletFormatter)
 
 };
-
 
 
 // ----- client code -----

--- a/examples/ex_newformatter.cpp
+++ b/examples/ex_newformatter.cpp
@@ -67,7 +67,7 @@ int main() {
 
     std::cout << "Right-adjusted to fixed-width (20):" << std::endl;
     for (const auto& x: data) {
-        std::cout << str(withf(x, ff(20))) << std::endl;
+        std::cout << str(withf(x, align_right(20))) << std::endl;
     }
 
     return 0;

--- a/examples/ex_newformatter.cpp
+++ b/examples/ex_newformatter.cpp
@@ -18,7 +18,7 @@ struct Triplet {
 //
 // The implementation can build on top of string_builder
 //
-class TripletFormatter : public clue::fmt::formatter_base<TripletFormatter> {
+class TripletFormatter : public clue::formatter_base<TripletFormatter> {
 public:
     template<typename charT>
     size_t operator() (const Triplet& t, charT *buf, size_t buf_len) const {
@@ -35,7 +35,7 @@ public:
             return s.size();
         } else {
             // compute the length of the formatted string
-            using namespace clue::fmt;
+            using clue::ndigits;
             size_t m1 = ndigits(t.v1, 10);
             size_t m2 = ndigits(t.v2, 10);
             size_t m3 = ndigits(t.v3, 10);
@@ -62,12 +62,12 @@ int main() {
     }
 
     for (const auto& x: data) {
-        std::cout << fmt::str(x) << std::endl;
+        std::cout << str(x) << std::endl;
     }
 
     std::cout << "Right-adjusted to fixed-width (20):" << std::endl;
     for (const auto& x: data) {
-        std::cout << fmt::str(fmt::with(x, fmt::ff(20))) << std::endl;
+        std::cout << str(with(x, ff(20))) << std::endl;
     }
 
     return 0;

--- a/examples/ex_newformatter.cpp
+++ b/examples/ex_newformatter.cpp
@@ -59,18 +59,12 @@ public:
     }
 };
 
+
+// set TripletFormatter as default for Triplet
+CLUE_DEFAULT_FORMATTER(const Triplet&, TripletFormatter)
+
 };
 
-// register the formatter as default for my::Triplet
-
-namespace clue { namespace fmt {
-
-template<> struct default_formatter<mylib::Triplet> {
-    using type = mylib::TripletFormatter;
-    static constexpr type get() noexcept { return type{}; }
-};
-
-} }  // end namespace clue::fmt
 
 
 // ----- client code -----

--- a/examples/ex_newformatter.cpp
+++ b/examples/ex_newformatter.cpp
@@ -67,7 +67,7 @@ int main() {
 
     std::cout << "Right-adjusted to fixed-width (20):" << std::endl;
     for (const auto& x: data) {
-        std::cout << str(with(x, ff(20))) << std::endl;
+        std::cout << str(withf(x, ff(20))) << std::endl;
     }
 
     return 0;

--- a/examples/ex_newformatter.cpp
+++ b/examples/ex_newformatter.cpp
@@ -84,7 +84,7 @@ int main() {
 
     std::cout << "Right-adjusted to fixed-width (20):" << std::endl;
     for (const auto& x: data) {
-        std::cout << fmt::str(fmt::with(x, 20)) << std::endl;
+        std::cout << fmt::str(fmt::with(x, fmt::ff(20))) << std::endl;
     }
 
     return 0;

--- a/include/clue/formatting.hpp
+++ b/include/clue/formatting.hpp
@@ -21,9 +21,9 @@ inline auto with(const T& x, const fieldfmt& fs) ->
 
 template<typename T, typename Fmt>
 inline ::std::string strf(const T& x, const Fmt& fmt) {
-    size_t fmt_len = fmt.max_formatted_length(x);
+    size_t fmt_len = fmt(x, static_cast<char*>(nullptr), 0);
     ::std::string s(fmt_len, '\0');
-    size_t wlen = fmt.formatted_write(x, const_cast<char*>(s.data()), fmt_len + 1);
+    size_t wlen = fmt(x, const_cast<char*>(s.data()), fmt_len + 1);
     CLUE_ASSERT(wlen <= fmt_len);
     if (wlen < fmt_len) {
         s.resize(wlen);

--- a/include/clue/formatting.hpp
+++ b/include/clue/formatting.hpp
@@ -5,7 +5,6 @@
 #include <clue/string_builder.hpp>
 
 namespace clue {
-namespace fmt {
 
 template<typename T, typename Fmt>
 inline enable_if_t<::std::is_class<Fmt>::value, with_fmt_t<T, Fmt>>
@@ -41,7 +40,7 @@ inline std::string str(const T& x) {
 }
 
 template<typename T, typename Fmt>
-inline ::std::string str(fmt::with_fmt_t<T, Fmt> wfmt) {
+inline ::std::string str(with_fmt_t<T, Fmt> wfmt) {
     return strf(wfmt.value, wfmt.formatter);
 }
 
@@ -68,7 +67,6 @@ inline std::string str(const T1& x, Rest&&... rest) {
     return sb.str();
 }
 
-} // end namespace fmt
 } // end namespace clue
 
 #endif

--- a/include/clue/formatting.hpp
+++ b/include/clue/formatting.hpp
@@ -8,14 +8,14 @@ namespace clue {
 
 template<typename T, typename Fmt>
 inline enable_if_t<::std::is_class<Fmt>::value, with_fmt_t<T, Fmt>>
-with(const T& v, const Fmt& fmt) {
+withf(const T& v, const Fmt& fmt) {
     return with_fmt_t<T, Fmt>{v, fmt};
 }
 
 template<typename T>
-inline auto with(const T& x, const fieldfmt& fs) ->
+inline auto withf(const T& x, const fieldfmt& fs) ->
     with_fmt_t<T, field_formatter<decltype(get_default_formatter(x))> > {
-    return with(x, get_default_formatter(x) | fs);
+    return withf(x, get_default_formatter(x) | fs);
 }
 
 template<typename T, typename Fmt>

--- a/include/clue/formatting.hpp
+++ b/include/clue/formatting.hpp
@@ -14,7 +14,7 @@ with(const T& v, const Fmt& fmt) {
 }
 
 template<typename T>
-inline auto with(const T& x, ffspec_t fs) ->
+inline auto with(const T& x, const fieldfmt& fs) ->
     with_fmt_t<T, field_formatter<decltype(get_default_formatter(x))> > {
     return with(x, get_default_formatter(x) | fs);
 }

--- a/include/clue/formatting.hpp
+++ b/include/clue/formatting.hpp
@@ -7,7 +7,18 @@
 namespace clue {
 namespace fmt {
 
-// to-string formatting
+template<typename T>
+inline auto with(const T& v, size_t width, bool ljust=false) ->
+    decltype(with(v, get_default_formatter(v), width, ljust)) {
+    return with(v, get_default_formatter(v), width, ljust);
+}
+
+
+//===============================================
+//
+//  String formatting
+//
+//===============================================
 
 template<typename T, typename Fmt>
 inline ::std::string strf(const T& x, const Fmt& fmt) {

--- a/include/clue/formatting_base.hpp
+++ b/include/clue/formatting_base.hpp
@@ -309,17 +309,17 @@ private:
 //
 //===============================================
 
-struct ffspec_t {
+struct fieldfmt {
     size_t width;
     bool leftjust;
 };
 
-constexpr ffspec_t ff(size_t width) noexcept {
-    return ffspec_t{width, false};
+constexpr fieldfmt ff(size_t width) noexcept {
+    return fieldfmt{width, false};
 }
 
-constexpr ffspec_t ff(size_t width, bool leftjust) noexcept {
-    return ffspec_t{width, leftjust};
+constexpr fieldfmt ff(size_t width, bool leftjust) noexcept {
+    return fieldfmt{width, leftjust};
 }
 
 
@@ -331,7 +331,7 @@ private:
     bool leftjust_;
 
 public:
-    field_formatter(const Fmt& f, const ffspec_t& fs) :
+    field_formatter(const Fmt& f, const fieldfmt& fs) :
         fmt_(f), width_(fs.width), leftjust_(fs.leftjust) {}
 
     constexpr const Fmt& formatter() const {
@@ -346,7 +346,7 @@ public:
         return leftjust_;
     }
 
-    field_formatter operator | (const ffspec_t& fs) const {
+    field_formatter operator | (const fieldfmt& fs) const {
         return field_formatter(fmt_, fs);
     }
 
@@ -365,7 +365,7 @@ public:
 
 template<class Fmt>
 inline enable_if_t<::std::is_class<Fmt>::value, field_formatter<Fmt>>
-operator | (const Fmt& f, const ffspec_t& fs) {
+operator | (const Fmt& f, const fieldfmt& fs) {
     return field_formatter<Fmt>(f, fs);
 }
 

--- a/include/clue/formatting_base.hpp
+++ b/include/clue/formatting_base.hpp
@@ -16,7 +16,6 @@
 #include <algorithm>
 
 namespace clue {
-namespace fmt {
 
 //===============================================
 //
@@ -24,13 +23,22 @@ namespace fmt {
 //
 //===============================================
 
-enum {
+enum class fmt_flag_t: unsigned int {
     uppercase = 0x01,
     padzeros  = 0x02,
     showpos   = 0x04
 };
 
-typedef unsigned int fmt_flag_t;
+constexpr fmt_flag_t operator | (fmt_flag_t a, fmt_flag_t b) noexcept {
+    return static_cast<fmt_flag_t>(
+        static_cast<unsigned int>(a) | static_cast<unsigned int>(b));
+}
+
+constexpr bool masked_any(fmt_flag_t a, fmt_flag_t m) noexcept {
+    return static_cast<bool>(
+        static_cast<unsigned int>(a) & static_cast<unsigned int>(m));
+}
+
 
 // with functions
 
@@ -344,7 +352,6 @@ default_string_formatter<T> get_default_formatter(const ::std::basic_string<T, T
 }
 
 
-} // end namespace fmt
 } // end namespace clue
 
 #endif

--- a/include/clue/formatting_base.hpp
+++ b/include/clue/formatting_base.hpp
@@ -30,7 +30,7 @@ enum {
     showpos   = 0x04
 };
 
-typedef unsigned int flag_t;
+typedef unsigned int fmt_flag_t;
 
 // with functions
 

--- a/include/clue/formatting_base.hpp
+++ b/include/clue/formatting_base.hpp
@@ -294,82 +294,57 @@ private:
     }
 };
 
-
 //===============================================
 //
-//  Generic formatting
+//  Default formatting
 //
 //===============================================
 
-template<typename T> struct default_formatter;
+#define CLUE_DEFAULT_FORMATTER(TDecl, F) \
+    F get_default_formatter(TDecl) noexcept { \
+        return F{};\
+    }
 
-template<typename T>
-inline typename default_formatter<decay_t<T>>::type
-get_default_formatter(const T& x) noexcept {
-    return default_formatter<decay_t<T>>::get();
-}
+// for boolean
 
-template<typename T>
-using default_formatter_t = typename default_formatter<T>::type;
+CLUE_DEFAULT_FORMATTER(bool, default_bool_formatter)
 
-// for bool
+// for characters
 
-template<> struct default_formatter<bool> {
-    using type = default_bool_formatter;
-    static constexpr type get() noexcept { return type{}; }
-};
+CLUE_DEFAULT_FORMATTER(char,     default_char_formatter)
+CLUE_DEFAULT_FORMATTER(wchar_t,  default_char_formatter)
+CLUE_DEFAULT_FORMATTER(char16_t, default_char_formatter)
+CLUE_DEFAULT_FORMATTER(char32_t, default_char_formatter)
 
-// for characters and char*
+// for strings
 
-#define CLUE_DEFINE_DEFAULT_CHAR_AND_STR_FORMATTER(CHARTYPE) \
-    template<> struct default_formatter<CHARTYPE> { \
-        using type = default_char_formatter; \
-        static constexpr type get() noexcept { return type{}; } \
-    }; \
-    template<> struct default_formatter<CHARTYPE*> { \
-        using type = default_string_formatter; \
-        static constexpr type get() noexcept { return type{}; } \
-    };  \
-    template<> struct default_formatter<const CHARTYPE*> { \
-        using type = default_string_formatter; \
-        static constexpr type get() noexcept { return type{}; } \
-    };
-
-CLUE_DEFINE_DEFAULT_CHAR_AND_STR_FORMATTER(char)
-CLUE_DEFINE_DEFAULT_CHAR_AND_STR_FORMATTER(wchar_t)
-CLUE_DEFINE_DEFAULT_CHAR_AND_STR_FORMATTER(char16_t)
-CLUE_DEFINE_DEFAULT_CHAR_AND_STR_FORMATTER(char32_t)
-
-// for string types
+CLUE_DEFAULT_FORMATTER(const char*,     default_string_formatter)
+CLUE_DEFAULT_FORMATTER(const wchar_t*,  default_string_formatter)
+CLUE_DEFAULT_FORMATTER(const char16_t*, default_string_formatter)
+CLUE_DEFAULT_FORMATTER(const char32_t*, default_string_formatter)
 
 template<typename charT, typename Traits>
-struct default_formatter<basic_string_view<charT, Traits>> {
-    using type = default_string_formatter;
-    static constexpr type get() noexcept {
-        return type{};
-    }
-};
+default_string_formatter get_default_formatter(const basic_string_view<charT, Traits>&) noexcept {
+    return default_string_formatter{};
+}
 
 template<typename charT, typename Traits, typename Allocator>
-struct default_formatter<::std::basic_string<charT, Traits, Allocator>> {
-    using type = default_string_formatter;
-    static constexpr type get() noexcept {
-        return type{};
-    }
-};
+default_string_formatter get_default_formatter(const ::std::basic_string<charT, Traits, Allocator>&) noexcept {
+    return default_string_formatter{};
+}
 
 // with functions
 
 template<typename T, typename Fmt>
 struct with_fmt_t {
     const T& value;
-    const Fmt& formatter;
+    const Fmt formatter;
 };
 
 template<typename T, typename Fmt>
 struct with_fmt_ex_t {
     const T& value;
-    const Fmt& formatter;
+    const Fmt formatter;
     size_t width;
     bool leftjust;
 };
@@ -384,12 +359,6 @@ template<typename T, typename Fmt>
 inline enable_if_t<::std::is_class<Fmt>::value, with_fmt_ex_t<T, Fmt>>
 with(const T& v, const Fmt& fmt, size_t width, bool ljust=false) {
     return with_fmt_ex_t<T, Fmt>{v, fmt, width, ljust};
-}
-
-template<typename T>
-inline with_fmt_ex_t<T, default_formatter_t<decay_t<T>>>
-with(const T& v, size_t width, bool ljust=false) {
-    return with(v, default_formatter<decay_t<T>>::get(), width, ljust);
 }
 
 

--- a/include/clue/formatting_base.hpp
+++ b/include/clue/formatting_base.hpp
@@ -23,18 +23,18 @@ namespace clue {
 //
 //===============================================
 
-enum class fmt_flag_t: unsigned int {
+enum class fmt: unsigned int {
     uppercase = 0x01,
     padzeros  = 0x02,
     showpos   = 0x04
 };
 
-constexpr fmt_flag_t operator | (fmt_flag_t a, fmt_flag_t b) noexcept {
-    return static_cast<fmt_flag_t>(
+constexpr fmt operator | (fmt a, fmt b) noexcept {
+    return static_cast<fmt>(
         static_cast<unsigned int>(a) | static_cast<unsigned int>(b));
 }
 
-constexpr bool masked_any(fmt_flag_t a, fmt_flag_t m) noexcept {
+constexpr bool masked_any(fmt a, fmt m) noexcept {
     return static_cast<bool>(
         static_cast<unsigned int>(a) & static_cast<unsigned int>(m));
 }

--- a/include/clue/formatting_base.hpp
+++ b/include/clue/formatting_base.hpp
@@ -3,7 +3,7 @@
 
 #include <clue/config.hpp>
 #include <clue/type_traits.hpp>
-#include <clue/string_view.hpp>
+#include <clue/stringex.hpp>
 
 #include <cstdio>
 #include <cstdlib>
@@ -40,6 +40,20 @@ struct with_fmt_t {
     const Fmt formatter;
 };
 
+struct fieldfmt {
+    size_t width;
+    bool leftjust;
+};
+
+constexpr fieldfmt ff(size_t width) noexcept {
+    return fieldfmt{width, false};
+}
+
+constexpr fieldfmt ff(size_t width, bool leftjust) noexcept {
+    return fieldfmt{width, leftjust};
+}
+
+
 //===============================================
 //
 //  C-format
@@ -63,69 +77,83 @@ inline ::std::string c_sprintf(const char *fmt, ...) {
 
 //===============================================
 //
-//  Formatter implementation helper
+//  Formatter base
 //
 //===============================================
 
-template<typename Fmt, typename T, typename charT>
-size_t formatted_write_unknown_length(
-    const Fmt& fmt,     // the formatter
-    const T& x,         // the value to be formatted
-    size_t width,       // field width
-    bool leftjust,      // whether to left-adjust
-    charT *buf,         // buffer base
-    size_t buf_len)     // buffer size
-{
-    CLUE_ASSERT(buf_len > width);
-    size_t n = fmt.formatted_write(x, buf, buf_len);
-    CLUE_ASSERT(buf_len > n);
-    if (width > n) {
-        // re-justify
-        size_t np = width - n;
-        if (leftjust) {
-            ::std::fill_n(buf + n, np, static_cast<charT>(' '));
-            buf[width] = (charT)('\0');
-        } else {
-            ::std::memmove(buf + np, buf, n * sizeof(charT));
-            ::std::fill_n(buf, np, static_cast<charT>(' '));
-        }
-        buf[width] = static_cast<charT>('\0');
-        return width;
-    } else {
-        return n;
+template<typename Fmt, bool LengthExact=false>
+class formatter_base {
+private:
+    const Fmt& derived() const {
+        return static_cast<const Fmt&>(*this);
     }
-}
 
-template<typename Fmt, typename T, typename charT>
-size_t formatted_write_known_length(
-    const Fmt& fmt,     // the formatter
-    const T& x,         // the value to be formatted
-    size_t n,           // the length of formatted x
-    size_t width,       // field width
-    bool leftjust,      // whether to left-adjust
-    charT *buf,         // buffer base
-    size_t buf_len)     // buffer size
-{
-    CLUE_ASSERT(buf_len > n && buf_len > width);
-    if (width > n) {
-        size_t np = width - n;
-        if (leftjust) {
-            size_t wlen = fmt.formatted_write(x, buf, n + 1);
-            CLUE_ASSERT(wlen == n);
-            ::std::fill_n(buf + n, np, (charT)(' '));
-            buf[width] = static_cast<charT>('\0');
+public:
+    template<typename T, typename charT>
+    size_t field_write(const T& x, const fieldfmt& fs, charT *buf, size_t buf_len) const {
+        const Fmt& f = derived();
+
+        const size_t w = fs.width;
+        CLUE_ASSERT(buf_len > w);
+
+        // first write
+        size_t n = f(x, buf, buf_len);
+        CLUE_ASSERT(buf_len > n);
+
+        if (w > n) {
+            // re-justify
+            size_t np = w - n;
+            if (fs.leftjust) {
+                ::std::fill_n(buf + n, np, static_cast<charT>(' '));
+                buf[w] = (charT)('\0');
+            } else {
+                ::std::memmove(buf + np, buf, n * sizeof(charT));
+                ::std::fill_n(buf, np, static_cast<charT>(' '));
+            }
+            buf[w] = static_cast<charT>('\0');
+            return w;
         } else {
-            ::std::fill_n(buf, np, static_cast<charT>(' '));
-            size_t wlen = fmt.formatted_write(x, buf + np, n + 1);
-            CLUE_ASSERT(wlen == n);
+            return n;
         }
-        return width;
-    } else {
-        size_t wlen = fmt.formatted_write(x, buf, n+1);
-        CLUE_ASSERT(wlen == n);
-        return n;
     }
-}
+};
+
+
+template<typename Fmt>
+class formatter_base<Fmt, true> {
+private:
+    const Fmt& derived() const {
+        return static_cast<const Fmt&>(*this);
+    }
+
+public:
+    template<typename T, typename charT>
+    size_t field_write(const T& x, const fieldfmt& fs, charT *buf, size_t buf_len) const {
+        const Fmt& f = derived();
+        const size_t n = f(x, static_cast<charT*>(nullptr), 0);
+        const size_t w = fs.width;
+
+        CLUE_ASSERT(buf_len > n && buf_len > w);
+        if (w > n) {
+            size_t np = w - n;
+            if (fs.leftjust) {
+                size_t wlen = f(x, buf, n + 1);
+                CLUE_ASSERT(wlen == n);
+                ::std::fill_n(buf + n, np, (charT)(' '));
+                buf[w] = static_cast<charT>('\0');
+            } else {
+                ::std::fill_n(buf, np, static_cast<charT>(' '));
+                size_t wlen = f(x, buf + np, n + 1);
+                CLUE_ASSERT(wlen == n);
+            }
+            return w;
+        } else {
+            size_t wlen = f(x, buf, n+1);
+            CLUE_ASSERT(wlen == n);
+            return n;
+        }
+    }
+};
 
 
 //===============================================
@@ -134,30 +162,23 @@ size_t formatted_write_known_length(
 //
 //===============================================
 
-class default_bool_formatter {
+class default_bool_formatter : public formatter_base<default_bool_formatter, true> {
 public:
-    constexpr size_t max_formatted_length(bool x) const noexcept {
-        return x ? 4 : 5;
-    }
-
     template<typename charT>
-    size_t formatted_write(bool x, charT *buf, size_t buf_len) const {
+    size_t operator() (bool x, charT *buf, size_t buf_len) const {
         if (x) {
-            CLUE_ASSERT(buf_len > 4);
-            std::copy_n("true", 5, buf);
+            if (buf) {
+                CLUE_ASSERT(buf_len > 4);
+                std::copy_n("true", 5, buf);
+            }
             return 4;
         } else {
-            CLUE_ASSERT(buf_len > 5);
-            std::copy_n("false", 6, buf);
+            if (buf) {
+                CLUE_ASSERT(buf_len > 5);
+                std::copy_n("false", 6, buf);
+            }
             return 5;
         }
-    }
-
-    template<typename charT>
-    size_t formatted_write(bool x, size_t width, bool ljust, charT *buf, size_t buf_len) const {
-        return formatted_write_known_length(
-            *this, x, max_formatted_length(x),
-            width, ljust, buf, buf_len);
     }
 };
 
@@ -168,24 +189,16 @@ public:
 //
 //===============================================
 
-class default_char_formatter {
+template<typename T>
+class default_char_formatter : public formatter_base<default_char_formatter<T>, true> {
 public:
     template<typename charT>
-    constexpr size_t max_formatted_length(charT c) const noexcept {
+    size_t operator() (T c, charT *buf, size_t buf_len) const {
+        if (buf) {
+            buf[0] = static_cast<charT>(c);
+            buf[1] = static_cast<charT>('\0');
+        }
         return 1;
-    }
-
-    template<typename charT>
-    size_t formatted_write(charT c, charT *buf, size_t buf_len) const {
-        buf[0] = c;
-        buf[1] = static_cast<charT>('\0');
-        return 1;
-    }
-
-    template<typename charT>
-    size_t formatted_write(charT c, size_t width, bool ljust, charT *buf, size_t buf_len) const {
-        return formatted_write_known_length(
-            *this, c, 1, width, ljust, buf, buf_len);
     }
 };
 
@@ -196,109 +209,40 @@ public:
 //
 //===============================================
 
-
-class default_string_formatter {
+template<typename T>
+class default_string_formatter : public formatter_base<default_string_formatter<T>, true> {
 public:
-    // max_formatted_length
-
-    template<typename charT>
-    constexpr size_t max_formatted_length(const charT *sz) const noexcept {
-        return ::std::char_traits<charT>::length(sz);
-    }
-
-    template<typename charT, typename Traits, typename Allocator>
-    constexpr size_t max_formatted_length(
-            const ::std::basic_string<charT, Traits, Allocator>& s) const noexcept {
-        return s.size();
-    }
-
-    template<typename charT, typename Traits>
-    constexpr size_t max_formatted_length(
-            const basic_string_view<charT, Traits>& sv) const noexcept {
-        return sv.size();
-    }
-
     // formatted_write
 
     template<typename charT>
-    size_t formatted_write(
-            const charT* s,
-            charT *buf, size_t buf_len) const noexcept {
-        const charT *p = s;
-        const charT *pend = s + buf_len;
-        while (*p && p != pend) *buf++ = *p++;
-        *buf = '\0';
-        return static_cast<size_t>(p - s);
-    }
-
-    template<typename charT, typename Traits, typename Allocator>
-    size_t formatted_write(
-            const ::std::basic_string<charT, Traits, Allocator>& s,
-            charT *buf, size_t buf_len) const noexcept {
-        return formatted_write_(s.data(), s.size(), buf, buf_len);
+    size_t operator() (const T* s, charT *buf, size_t buf_len) const noexcept {
+        if (buf) {
+            const T *p = s;
+            const T *pend = s + buf_len;
+            while (*p && p != pend) *buf++ = static_cast<charT>(*p++);
+            *buf = static_cast<charT>('\0');
+            return static_cast<size_t>(p - s);
+        } else {
+            return ::std::char_traits<T>::length(s);
+        }
     }
 
     template<typename charT, typename Traits>
-    size_t formatted_write(
-            const basic_string_view<charT, Traits>& sv,
-            charT *buf, size_t buf_len) const noexcept {
-        return formatted_write_(sv.data(), sv.size(), buf, buf_len);
-    }
-
-    // formatted_write (with width & left-just)
-
-    template<typename charT>
-    size_t formatted_write(
-            const charT* s, size_t width, bool ljust,
-            charT *buf, size_t buf_len) const noexcept {
-        size_t len = ::std::char_traits<charT>::length(s);
-        return formatted_write_(s, len, width, ljust, buf, buf_len);
-    }
-
-    template<typename charT, typename Traits, typename Allocator>
-    size_t formatted_write(
-            const ::std::basic_string<charT, Traits, Allocator>& s,
-            size_t width, bool ljust, charT *buf, size_t buf_len) const noexcept {
-        return formatted_write_(s.data(), s.size(), width, ljust, buf, buf_len);
-    }
-
-    template<typename charT, typename Traits>
-    size_t formatted_write(
-            const basic_string_view<charT, Traits>& sv,
-            size_t width, bool ljust, charT *buf, size_t buf_len) const noexcept {
-        return formatted_write_(sv.data(), sv.size(), width, ljust, buf, buf_len);
-    }
-
-private:
-    template<typename charT>
-    size_t formatted_write_(const charT *src, size_t n,
-                            charT *buf, size_t buf_len) const noexcept {
-        CLUE_ASSERT(n < buf_len);
-        ::std::memcpy(buf, src, n * sizeof(charT));
-        buf[n] = static_cast<charT>('\0');
+    size_t operator() (const basic_string_view<T, Traits>& sv,
+                       charT *buf, size_t buf_len) const noexcept {
+        const size_t n = sv.size();
+        if (buf) {
+            CLUE_ASSERT(n < buf_len);
+            ::std::copy(sv.begin(), sv.end(), buf);
+            buf[n] = static_cast<charT>('\0');
+        }
         return n;
     }
 
-    template<typename charT>
-    size_t formatted_write_(const charT *src, size_t n, size_t width, bool ljust,
-                            charT *buf, size_t buf_len) const noexcept {
-        CLUE_ASSERT(n < buf_len && width < buf_len);
-        if (width > n) {
-            size_t np = width - n;
-            if (ljust) {
-                ::std::memcpy(buf, src, n * sizeof(charT));
-                ::std::fill_n(buf + n, np, ' ');
-            } else {
-                ::std::fill_n(buf, np, ' ');
-                ::std::memcpy(buf + np, src, n * sizeof(charT));
-            }
-            buf[width] = static_cast<charT>('\0');
-            return width;
-        } else {
-            ::std::memcpy(buf, src, n * sizeof(charT));
-            buf[n] = static_cast<charT>('\0');
-            return n;
-        }
+    template<typename charT, typename Traits, typename Allocator>
+    size_t operator() (const ::std::basic_string<T, Traits, Allocator>& s,
+                       charT *buf, size_t buf_len) const noexcept {
+        return operator()(view(s), buf, buf_len);
     }
 };
 
@@ -308,19 +252,6 @@ private:
 //  Field formatting
 //
 //===============================================
-
-struct fieldfmt {
-    size_t width;
-    bool leftjust;
-};
-
-constexpr fieldfmt ff(size_t width) noexcept {
-    return fieldfmt{width, false};
-}
-
-constexpr fieldfmt ff(size_t width, bool leftjust) noexcept {
-    return fieldfmt{width, leftjust};
-}
 
 
 template<class Fmt>
@@ -338,6 +269,10 @@ public:
         return fmt_;
     }
 
+    constexpr fieldfmt spec() const {
+        return fieldfmt{width_, leftjust_};
+    }
+
     constexpr size_t width() const {
         return width_;
     }
@@ -351,15 +286,14 @@ public:
     }
 
 public:
-    template<typename T>
-    size_t max_formatted_length(const T& x) const noexcept {
-        size_t n = fmt_.max_formatted_length(x);
-        return n > width_ ? n : width_;
-    }
-
     template<typename T, typename charT>
-    size_t formatted_write(const T& x, charT *buf, size_t buf_len) const {
-        return fmt_.formatted_write(x, width_, leftjust_, buf, buf_len);
+    size_t operator() (const T& x, charT *buf, size_t buf_len) const {
+        if (buf) {
+            return fmt_.field_write(x, ff(width_, leftjust_), buf, buf_len);
+        } else {
+            size_t n = fmt_(x, static_cast<charT*>(nullptr), 0);
+            return n > width_ ? n : width_;
+        }
     }
 };
 
@@ -387,26 +321,26 @@ CLUE_DEFAULT_FORMATTER(bool, default_bool_formatter)
 
 // for characters
 
-CLUE_DEFAULT_FORMATTER(char,     default_char_formatter)
-CLUE_DEFAULT_FORMATTER(wchar_t,  default_char_formatter)
-CLUE_DEFAULT_FORMATTER(char16_t, default_char_formatter)
-CLUE_DEFAULT_FORMATTER(char32_t, default_char_formatter)
+CLUE_DEFAULT_FORMATTER(char,     default_char_formatter<char>)
+CLUE_DEFAULT_FORMATTER(wchar_t,  default_char_formatter<wchar_t>)
+CLUE_DEFAULT_FORMATTER(char16_t, default_char_formatter<char16_t>)
+CLUE_DEFAULT_FORMATTER(char32_t, default_char_formatter<char32_t>)
 
 // for strings
 
-CLUE_DEFAULT_FORMATTER(const char*,     default_string_formatter)
-CLUE_DEFAULT_FORMATTER(const wchar_t*,  default_string_formatter)
-CLUE_DEFAULT_FORMATTER(const char16_t*, default_string_formatter)
-CLUE_DEFAULT_FORMATTER(const char32_t*, default_string_formatter)
+CLUE_DEFAULT_FORMATTER(const char*,     default_string_formatter<char>)
+CLUE_DEFAULT_FORMATTER(const wchar_t*,  default_string_formatter<wchar_t>)
+CLUE_DEFAULT_FORMATTER(const char16_t*, default_string_formatter<char16_t>)
+CLUE_DEFAULT_FORMATTER(const char32_t*, default_string_formatter<char32_t>)
 
-template<typename charT, typename Traits>
-default_string_formatter get_default_formatter(const basic_string_view<charT, Traits>&) noexcept {
-    return default_string_formatter{};
+template<typename T, typename Traits>
+default_string_formatter<T> get_default_formatter(const basic_string_view<T, Traits>&) noexcept {
+    return default_string_formatter<T>{};
 }
 
-template<typename charT, typename Traits, typename Allocator>
-default_string_formatter get_default_formatter(const ::std::basic_string<charT, Traits, Allocator>&) noexcept {
-    return default_string_formatter{};
+template<typename T, typename Traits, typename Allocator>
+default_string_formatter<T> get_default_formatter(const ::std::basic_string<T, Traits, Allocator>&) noexcept {
+    return default_string_formatter<T>{};
 }
 
 

--- a/include/clue/formatting_base.hpp
+++ b/include/clue/formatting_base.hpp
@@ -53,12 +53,12 @@ struct fieldfmt {
     bool leftjust;
 };
 
-constexpr fieldfmt ff(size_t width) noexcept {
-    return fieldfmt{width, false};
+constexpr fieldfmt align_left(size_t width) noexcept {
+    return fieldfmt{width, true};
 }
 
-constexpr fieldfmt ff(size_t width, bool leftjust) noexcept {
-    return fieldfmt{width, leftjust};
+constexpr fieldfmt align_right(size_t width) noexcept {
+    return fieldfmt{width, false};
 }
 
 
@@ -297,7 +297,7 @@ public:
     template<typename T, typename charT>
     size_t operator() (const T& x, charT *buf, size_t buf_len) const {
         if (buf) {
-            return fmt_.field_write(x, ff(width_, leftjust_), buf, buf_len);
+            return fmt_.field_write(x, fieldfmt{width_, leftjust_}, buf, buf_len);
         } else {
             size_t n = fmt_(x, static_cast<charT*>(nullptr), 0);
             return n > width_ ? n : width_;

--- a/include/clue/internal/numfmt.hpp
+++ b/include/clue/internal/numfmt.hpp
@@ -5,7 +5,6 @@
 #include <cmath>
 
 namespace clue {
-namespace fmt {
 namespace details {
 
 using ::std::size_t;
@@ -301,7 +300,6 @@ inline const char* float_cfmt_impl(
 
 
 } // end namespace details
-} // end namespace fmt
 } // end namespace clue
 
 

--- a/include/clue/numformat.hpp
+++ b/include/clue/numformat.hpp
@@ -32,7 +32,7 @@ ndigits(T x, const unsigned base=10) noexcept {
 class int_formatter {
 private:
     unsigned base_;
-    flag_t flags_;
+    fmt_flag_t flags_;
 
 public:
     // construction & properties
@@ -43,25 +43,25 @@ public:
     explicit constexpr int_formatter(unsigned base) noexcept :
         base_(base), flags_(0) {}
 
-    constexpr int_formatter(unsigned base, flag_t flags) :
+    constexpr int_formatter(unsigned base, fmt_flag_t flags) :
         base_(base), flags_(flags) {}
 
     constexpr unsigned base() const noexcept { return base_; }
-    constexpr flag_t flags() const noexcept { return flags_; }
+    constexpr fmt_flag_t flags() const noexcept { return flags_; }
 
     constexpr int_formatter base(unsigned v) const noexcept {
         return int_formatter(v, flags_);
     }
 
-    constexpr int_formatter flags(flag_t v) const noexcept {
+    constexpr int_formatter flags(fmt_flag_t v) const noexcept {
         return int_formatter(base_, v);
     }
 
-    constexpr int_formatter operator | (flag_t v) const noexcept {
+    constexpr int_formatter operator | (fmt_flag_t v) const noexcept {
         return int_formatter(base_, flags_ | v);
     }
 
-    constexpr bool any(flag_t msk) const noexcept {
+    constexpr bool any(fmt_flag_t msk) const noexcept {
         return static_cast<bool>(flags_ & msk);
     }
 
@@ -115,9 +115,9 @@ public:
     // properties
 
     constexpr unsigned base() const noexcept { return 10; }
-    constexpr flag_t flags() const noexcept { return 0; }
+    constexpr fmt_flag_t flags() const noexcept { return 0; }
 
-    constexpr bool any(flag_t msk) const noexcept {
+    constexpr bool any(fmt_flag_t msk) const noexcept {
         return false;
     }
 
@@ -187,7 +187,7 @@ class float_formatter {
 private:
     typedef details::float_fmt_traits<Tag> fmt_traits_t;
     size_t precision_;
-    flag_t flags_;
+    fmt_flag_t flags_;
 
 public:
     typedef Tag tag_type;
@@ -197,26 +197,26 @@ public:
     constexpr float_formatter() noexcept :
         precision_(6), flags_(0) {}
 
-    constexpr float_formatter(size_t precision, flag_t flags) :
+    constexpr float_formatter(size_t precision, fmt_flag_t flags) :
         precision_(precision), flags_(flags) {}
 
     constexpr size_t precision() const noexcept { return precision_; }
-    constexpr flag_t flags() const noexcept { return flags_; }
+    constexpr fmt_flag_t flags() const noexcept { return flags_; }
 
 
     constexpr float_formatter precision(size_t v) const noexcept {
         return float_formatter(v, flags_);
     }
 
-    constexpr float_formatter flags(flag_t v) const noexcept {
+    constexpr float_formatter flags(fmt_flag_t v) const noexcept {
         return float_formatter(precision_, v);
     }
 
-    constexpr float_formatter operator | (flag_t v) const noexcept {
+    constexpr float_formatter operator | (fmt_flag_t v) const noexcept {
         return float_formatter(precision_, flags_ | v);
     }
 
-    constexpr bool any(flag_t msk) const noexcept {
+    constexpr bool any(fmt_flag_t msk) const noexcept {
         return static_cast<bool>(flags_ & msk);
     }
 

--- a/include/clue/numformat.hpp
+++ b/include/clue/numformat.hpp
@@ -224,7 +224,7 @@ public:
     template<typename charT>
     size_t operator() (double x, charT *buf, size_t buf_len) const {
         if (buf) {
-            return field_write(x, ff(0), buf, buf_len);
+            return field_write(x, align_right(0), buf, buf_len);
         } else {
             size_t n = 0;
             if (::std::isfinite(x)) {

--- a/include/clue/numformat.hpp
+++ b/include/clue/numformat.hpp
@@ -4,6 +4,7 @@
 #include <clue/formatting_base.hpp>
 #include <clue/internal/numfmt.hpp>
 #include <clue/internal/grisu.hpp>
+#include <cstdint>
 
 namespace clue {
 namespace fmt {
@@ -291,21 +292,15 @@ constexpr int_formatter hex() noexcept { return int_formatter(16); }
 constexpr fixed_formatter fixed() noexcept { return fixed_formatter(); }
 constexpr sci_formatter   sci()   noexcept { return sci_formatter();   }
 
-namespace details {
-    template<typename T>
-    using default_arith_formatter_t =
-        conditional_t<::std::is_integral<T>::value,
-            default_int_formatter,
-            default_float_formatter>;
-}
 
 template<typename T>
-constexpr enable_if_t<
-    ::std::is_arithmetic<T>::value,
-    details::default_arith_formatter_t<T>>
-get_default_formatter(const T&) {
-    return details::default_arith_formatter_t<T>{};
+constexpr enable_if_t<::std::is_integral<T>::value, default_int_formatter>
+get_default_formatter(const T& x) {
+    return default_int_formatter{};
 }
+
+CLUE_DEFAULT_FORMATTER(float,  default_float_formatter);
+CLUE_DEFAULT_FORMATTER(double, default_float_formatter);
 
 
 } // end namespace fmt

--- a/include/clue/numformat.hpp
+++ b/include/clue/numformat.hpp
@@ -17,7 +17,8 @@ namespace fmt {
 // ndigits
 
 template<typename T>
-inline size_t ndigits(T x, const unsigned base) noexcept {
+inline enable_if_t<::std::is_integral<T>::value, size_t>
+ndigits(T x, const unsigned base=10) noexcept {
     auto u = details::uabs(x);
     switch (base) {
         case  8: return details::ndigits_oct(u);

--- a/include/clue/numformat.hpp
+++ b/include/clue/numformat.hpp
@@ -31,36 +31,36 @@ ndigits(T x, const unsigned base=10) noexcept {
 class int_formatter {
 private:
     unsigned base_;
-    fmt_flag_t flags_;
+    fmt flags_;
 
 public:
     // construction & properties
 
     constexpr int_formatter() noexcept :
-        base_(10), flags_(static_cast<fmt_flag_t>(0)) {}
+        base_(10), flags_(static_cast<fmt>(0)) {}
 
     explicit constexpr int_formatter(unsigned base) noexcept :
-        base_(base), flags_(static_cast<fmt_flag_t>(0)) {}
+        base_(base), flags_(static_cast<fmt>(0)) {}
 
-    constexpr int_formatter(unsigned base, fmt_flag_t flags) :
+    constexpr int_formatter(unsigned base, fmt flags) :
         base_(base), flags_(flags) {}
 
     constexpr unsigned base() const noexcept { return base_; }
-    constexpr fmt_flag_t flags() const noexcept { return flags_; }
+    constexpr fmt flags() const noexcept { return flags_; }
 
     constexpr int_formatter base(unsigned v) const noexcept {
         return int_formatter(v, flags_);
     }
 
-    constexpr int_formatter flags(fmt_flag_t v) const noexcept {
+    constexpr int_formatter flags(fmt v) const noexcept {
         return int_formatter(base_, v);
     }
 
-    constexpr int_formatter operator | (fmt_flag_t v) const noexcept {
+    constexpr int_formatter operator | (fmt v) const noexcept {
         return int_formatter(base_, flags_ | v);
     }
 
-    constexpr bool any(fmt_flag_t msk) const noexcept {
+    constexpr bool any(fmt msk) const noexcept {
         return masked_any(flags_, msk);
     }
 
@@ -69,7 +69,7 @@ public:
     template<typename T, typename charT>
     size_t operator() (T x, charT *buf, size_t buf_len) const {
         if (buf) {
-            bool showpos_ = any(fmt_flag_t::showpos);
+            bool showpos_ = any(fmt::showpos);
             switch (base_) {
                 case  8:
                     return details::render(x, details::int_render_helper<T,8>(x),
@@ -78,21 +78,21 @@ public:
                     return details::render(x, details::int_render_helper<T,10>(x),
                         showpos_, buf, buf_len);
                 case 16:
-                    return details::render(x, details::int_render_helper<T,16>(x, any(fmt_flag_t::uppercase)),
+                    return details::render(x, details::int_render_helper<T,16>(x, any(fmt::uppercase)),
                         showpos_, buf, buf_len);
             }
             return 0;
         } else {
             size_t n = ndigits(x, base_);
-            if (x < 0 || any(fmt_flag_t::showpos)) n++;
+            if (x < 0 || any(fmt::showpos)) n++;
             return n;
         }
     }
 
     template<typename T, typename charT>
     size_t field_write(T x, const fieldfmt& fs, charT *buf, size_t buf_len) const {
-        bool showpos_ = any(fmt_flag_t::showpos);
-        bool padzeros_ = any(fmt_flag_t::padzeros);
+        bool showpos_ = any(fmt::showpos);
+        bool padzeros_ = any(fmt::padzeros);
         switch (base_) {
             case  8:
                 return details::render(x, details::int_render_helper<T,8>(x),
@@ -101,7 +101,7 @@ public:
                 return details::render(x, details::int_render_helper<T,10>(x),
                     showpos_, padzeros_, fs.width, fs.leftjust, buf, buf_len);
             case 16:
-                return details::render(x, details::int_render_helper<T,16>(x, any(fmt_flag_t::uppercase)),
+                return details::render(x, details::int_render_helper<T,16>(x, any(fmt::uppercase)),
                     showpos_, padzeros_, fs.width, fs.leftjust, buf, buf_len);
         }
         return 0;
@@ -114,9 +114,9 @@ public:
     // properties
 
     constexpr unsigned base() const noexcept { return 10; }
-    constexpr fmt_flag_t flags() const noexcept { return static_cast<fmt_flag_t>(0); }
+    constexpr fmt flags() const noexcept { return static_cast<fmt>(0); }
 
-    constexpr bool any(fmt_flag_t msk) const noexcept {
+    constexpr bool any(fmt msk) const noexcept {
         return false;
     }
 
@@ -126,10 +126,10 @@ public:
     size_t operator() (T x, charT *buf, size_t buf_len) const {
         if (buf) {
             return details::render(x,
-                details::int_render_helper<T,10>(x), any(fmt_flag_t::showpos), buf, buf_len);
+                details::int_render_helper<T,10>(x), any(fmt::showpos), buf, buf_len);
         } else {
             size_t n = details::ndigits_dec(details::uabs(x));
-            if (x < 0 || any(fmt_flag_t::showpos)) n++;
+            if (x < 0 || any(fmt::showpos)) n++;
             return n;
         }
     }
@@ -186,7 +186,7 @@ class float_formatter {
 private:
     typedef details::float_fmt_traits<Tag> fmt_traits_t;
     size_t precision_;
-    fmt_flag_t flags_;
+    fmt flags_;
 
 public:
     typedef Tag tag_type;
@@ -194,28 +194,28 @@ public:
     // construction & properties
 
     constexpr float_formatter() noexcept :
-        precision_(6), flags_(static_cast<fmt_flag_t>(0)) {}
+        precision_(6), flags_(static_cast<fmt>(0)) {}
 
-    constexpr float_formatter(size_t precision, fmt_flag_t flags) :
+    constexpr float_formatter(size_t precision, fmt flags) :
         precision_(precision), flags_(flags) {}
 
     constexpr size_t precision() const noexcept { return precision_; }
-    constexpr fmt_flag_t flags() const noexcept { return flags_; }
+    constexpr fmt flags() const noexcept { return flags_; }
 
 
     constexpr float_formatter precision(size_t v) const noexcept {
         return float_formatter(v, flags_);
     }
 
-    constexpr float_formatter flags(fmt_flag_t v) const noexcept {
+    constexpr float_formatter flags(fmt v) const noexcept {
         return float_formatter(precision_, v);
     }
 
-    constexpr float_formatter operator | (fmt_flag_t v) const noexcept {
+    constexpr float_formatter operator | (fmt v) const noexcept {
         return float_formatter(precision_, flags_ | v);
     }
 
-    constexpr bool any(fmt_flag_t msk) const noexcept {
+    constexpr bool any(fmt msk) const noexcept {
         return masked_any(flags_, msk);
     }
 
@@ -228,12 +228,12 @@ public:
         } else {
             size_t n = 0;
             if (::std::isfinite(x)) {
-                n = fmt_traits_t::maxfmtlength(x, precision_, any(fmt_flag_t::showpos));
+                n = fmt_traits_t::maxfmtlength(x, precision_, any(fmt::showpos));
             } else if (::std::isinf(x)) {
-                n = ::std::signbit(x) || any(fmt_flag_t::showpos) ? 4 : 3;
+                n = ::std::signbit(x) || any(fmt::showpos) ? 4 : 3;
             } else {
                 CLUE_ASSERT(::std::isnan(x));
-                n = any(fmt_flag_t::showpos) ? 4 : 3;
+                n = any(fmt::showpos) ? 4 : 3;
             }
             return n;
         }
@@ -242,9 +242,9 @@ public:
     template<typename charT>
     size_t field_write(double x, const fieldfmt& fs, charT *buf, size_t buf_len) const {
         char cfmt[16];
-        const char fsym = details::float_fmt_traits<Tag>::printf_sym(any(fmt_flag_t::uppercase));
+        const char fsym = details::float_fmt_traits<Tag>::printf_sym(any(fmt::uppercase));
         details::float_cfmt_impl(cfmt, fsym, fs.width, precision_,
-                fs.leftjust, any(fmt_flag_t::showpos), any(fmt_flag_t::padzeros));
+                fs.leftjust, any(fmt::showpos), any(fmt::padzeros));
         size_t n = (size_t)::std::snprintf(buf, buf_len, cfmt, x);
         CLUE_ASSERT(n < buf_len);
         return n;

--- a/include/clue/numformat.hpp
+++ b/include/clue/numformat.hpp
@@ -293,33 +293,19 @@ constexpr sci_formatter   sci()   noexcept { return sci_formatter();   }
 
 namespace details {
     template<typename T>
-    struct default_formatter_map {
-        using type =
-            conditional_t<::std::is_integral<T>::value,
-                default_int_formatter,
-            conditional_t<::std::is_floating_point<T>::value,
-                default_float_formatter,
-                void
-        > >;
-    };
-
-    template<typename T>
-    using default_formatter_map_t = typename default_formatter_map<T>::type;
-
-    template<typename Fmt>
-    struct default_formatter_helper {
-        using type = Fmt;
-        static constexpr type get() noexcept { return type{}; }
-    };
-
-    template<>
-    struct default_formatter_helper<void> {};
+    using default_arith_formatter_t =
+        conditional_t<::std::is_integral<T>::value,
+            default_int_formatter,
+            default_float_formatter>;
 }
 
 template<typename T>
-struct default_formatter :
-    public details::default_formatter_helper<
-        details::default_formatter_map_t<T>> {};
+constexpr enable_if_t<
+    ::std::is_arithmetic<T>::value,
+    details::default_arith_formatter_t<T>>
+get_default_formatter(const T&) {
+    return details::default_arith_formatter_t<T>{};
+}
 
 
 } // end namespace fmt

--- a/include/clue/string_builder.hpp
+++ b/include/clue/string_builder.hpp
@@ -119,7 +119,7 @@ public:
 
     template<typename T>
     generic_string_builder& operator << (const T& x) {
-        writef(x, fmt::get_default_formatter(x));
+        writef(x, get_default_formatter(x));
         return *this;
     }
 
@@ -146,7 +146,7 @@ public:
     }
 
     template<typename T, typename Fmt>
-    generic_string_builder& operator << (fmt::with_fmt_t<T, Fmt> wfmt) {
+    generic_string_builder& operator << (const with_fmt_t<T, Fmt>& wfmt) {
         writef(wfmt.value, wfmt.formatter);
         return *this;
     }

--- a/include/clue/string_builder.hpp
+++ b/include/clue/string_builder.hpp
@@ -151,12 +151,6 @@ public:
         return *this;
     }
 
-    template<typename T, typename Fmt>
-    generic_string_builder& operator << (fmt::with_fmt_ex_t<T, Fmt> wfmt) {
-        writef(wfmt.value, wfmt.formatter, wfmt.width, wfmt.leftjust);
-        return *this;
-    }
-
     // Modifiers
 
     void clear() noexcept {

--- a/include/clue/string_builder.hpp
+++ b/include/clue/string_builder.hpp
@@ -100,9 +100,9 @@ public:
 
     template<typename T, typename Fmt>
     void writef(const T& x, Fmt&& fmt) {
-        size_t max_n = fmt.max_formatted_length(x);
+        size_t max_n = fmt(x, static_cast<charT*>(nullptr), 0);
         charT *p = take_next(max_n + 1);
-        size_t n = fmt.formatted_write(x, p, max_n + 1);
+        size_t n = fmt(x, p, max_n + 1);
         advance(n);
     }
 

--- a/perf/perf_numfmt.cpp
+++ b/perf/perf_numfmt.cpp
@@ -40,11 +40,11 @@ public:
 class WithClueFmt {
 private:
     char buf[128];
-    fmt::default_int_formatter dec_;
-    fmt::int_formatter hex_;
-    fmt::fixed_formatter fixed_;
-    fmt::sci_formatter sci_;
-    fmt::default_float_formatter exact_;
+    default_int_formatter dec_;
+    int_formatter hex_;
+    fixed_formatter fixed_;
+    sci_formatter sci_;
+    default_float_formatter exact_;
 
 public:
     WithClueFmt() : hex_(16) {}

--- a/perf/perf_numfmt.cpp
+++ b/perf/perf_numfmt.cpp
@@ -37,47 +37,6 @@ public:
     }
 };
 
-class WithSprintfChecked {
-private:
-    char buf[128];
-
-public:
-    const char *name() const {
-        return "with-sprintf:checked";
-    }
-
-    void put_dec(int x) {
-        size_t n = (size_t)(std::snprintf(nullptr, 0, "%d", x));
-        if (n < 128)
-            std::snprintf(buf, 128, "%d", x);
-    }
-
-    void put_hex(int x) {
-        size_t n = (size_t)(std::snprintf(nullptr, 0, "%x", x));
-        if (n < 128)
-            std::snprintf(buf, 128, "%x", x);
-    }
-
-    void put_fixed(double x) {
-        size_t n = (size_t)(std::snprintf(nullptr, 0, "%f", x));
-        if (n < 128)
-            std::snprintf(buf, 128, "%f", x);
-    }
-
-    void put_sci(double x) {
-        size_t n = (size_t)(std::snprintf(nullptr, 0, "%e", x));
-        if (n < 128)
-            std::snprintf(buf, 128, "%e", x);
-    }
-
-    void put_exact(double x) {
-        size_t n = (size_t)(std::snprintf(nullptr, 0, "%.17g", x));
-        if (n < 128)
-            std::snprintf(buf, 128, "%.17g", x);
-    }
-};
-
-
 class WithClueFmt {
 private:
     char buf[128];
@@ -95,70 +54,23 @@ public:
     }
 
     void put_dec(int x) {
-        dec_.formatted_write(x, buf, 128);
+        dec_(x, buf, 128);
     }
 
     void put_hex(int x) {
-        hex_.formatted_write(x, buf, 128);
+        hex_(x, buf, 128);
     }
 
     void put_fixed(double x) {
-        fixed_.formatted_write(x, buf, 128);
+        fixed_(x, buf, 128);
     }
 
     void put_sci(double x) {
-        sci_.formatted_write(x, buf, 128);
+        sci_(x, buf, 128);
     }
 
     void put_exact(double x) {
-        exact_.formatted_write(x, buf, 128);
-    }
-};
-
-class WithClueFmtChecked {
-private:
-    char buf[128];
-    fmt::default_int_formatter dec_;
-    fmt::int_formatter hex_;
-    fmt::fixed_formatter fixed_;
-    fmt::sci_formatter sci_;
-    fmt::default_float_formatter exact_;
-
-public:
-    WithClueFmtChecked() : hex_(16) {}
-
-    const char *name() const {
-        return "with-clue-fmt:checked";
-    }
-
-    void put_dec(int x) {
-        size_t n = dec_.max_formatted_length(x);
-        if (n < 128)
-            dec_.formatted_write(x, buf, 128);
-    }
-
-    void put_hex(int x) {
-        size_t n = hex_.max_formatted_length(x);
-        if (n < 128)
-            hex_.formatted_write(x, buf, 128);
-    }
-
-    void put_fixed(double x) {
-        size_t n = fixed_.max_formatted_length(x);
-        if (n < 128)
-            fixed_.formatted_write(x, buf, 128);
-    }
-
-    void put_sci(double x) {
-        size_t n = sci_.max_formatted_length(x);
-        if (n < 128)
-            sci_.formatted_write(x, buf, 128);
-    }
-
-    void put_exact(double x) {
-        size_t n = exact_.max_formatted_length(x);
-        if (n < 128)
-            exact_.formatted_write(x, buf, 128);
+        exact_(x, buf, 128);
     }
 };
 
@@ -230,9 +142,6 @@ int main() {
 
     measure_performance(WithSprintf(), ints, reals);
     measure_performance(WithClueFmt(), ints, reals);
-
-    measure_performance(WithSprintfChecked(), ints, reals);
-    measure_performance(WithClueFmtChecked(), ints, reals);
 
     return 0;
 }

--- a/tests/test_formatting.cpp
+++ b/tests/test_formatting.cpp
@@ -8,17 +8,15 @@ using std::size_t;
 
 
 TEST(Formatting, Csprintf) {
-    ASSERT_EQ("", fmt::c_sprintf(""));
-    ASSERT_EQ("123", fmt::c_sprintf("%d", 123));
-    ASSERT_EQ("2 + 3 = 5", fmt::c_sprintf("%d + %d = %d", 2, 3, 5));
-    ASSERT_EQ("12.5000", fmt::c_sprintf("%.4f", 12.5));
+    ASSERT_EQ("", c_sprintf(""));
+    ASSERT_EQ("123", c_sprintf("%d", 123));
+    ASSERT_EQ("2 + 3 = 5", c_sprintf("%d + %d = %d", 2, 3, 5));
+    ASSERT_EQ("12.5000", c_sprintf("%.4f", 12.5));
 }
 
 
 template<class T, class Fmt>
 void test_formatter(const T& x, const Fmt& f, const std::string& refstr) {
-    using fmt::ff;
-
     const size_t buf_len = 128;
     static char buf[buf_len];
 
@@ -50,18 +48,18 @@ void test_formatter(const T& x, const Fmt& f, const std::string& refstr) {
 }
 
 TEST(Formatting, DefaultBoolFmt) {
-    test_formatter(true, fmt::default_bool_formatter{}, "true");
-    test_formatter(false, fmt::default_bool_formatter{}, "false");
+    test_formatter(true, default_bool_formatter{}, "true");
+    test_formatter(false, default_bool_formatter{}, "false");
 }
 
 TEST(Formatting, DefaultCharFmt) {
-    test_formatter('a', fmt::default_char_formatter<char>{}, "a");
+    test_formatter('a', default_char_formatter<char>{}, "a");
 }
 
 void test_default_string_formatter(const std::string& src) {
-    test_formatter(src, fmt::default_string_formatter<char>{}, src);
-    test_formatter(string_view(src), fmt::default_string_formatter<char>{}, src);
-    test_formatter(src.c_str(), fmt::default_string_formatter<char>{}, src);
+    test_formatter(src, default_string_formatter<char>{}, src);
+    test_formatter(string_view(src), default_string_formatter<char>{}, src);
+    test_formatter(src.c_str(), default_string_formatter<char>{}, src);
 }
 
 TEST(Formatting, DefaultStringFmt) {
@@ -72,67 +70,62 @@ TEST(Formatting, DefaultStringFmt) {
 
 TEST(Formatting, FmtStr) {
     // char
-    ASSERT_EQ("a", fmt::str('a'));
+    ASSERT_EQ("a", str('a'));
 
     // string
-    ASSERT_EQ("abc", fmt::str("abc"));
-    ASSERT_EQ("abc", fmt::str(string_view("abc")));
-    ASSERT_EQ("abc", fmt::str(std::string("abc")));
+    ASSERT_EQ("abc", str("abc"));
+    ASSERT_EQ("abc", str(string_view("abc")));
+    ASSERT_EQ("abc", str(std::string("abc")));
 
     // boolean
-    ASSERT_EQ("true", fmt::str(true));
-    ASSERT_EQ("false", fmt::str(false));
+    ASSERT_EQ("true", str(true));
+    ASSERT_EQ("false", str(false));
 
     // integer
-    ASSERT_EQ("0", fmt::str(0));
-    ASSERT_EQ("123", fmt::str(123));
-    ASSERT_EQ("-456", fmt::str(-456));
+    ASSERT_EQ("0", str(0));
+    ASSERT_EQ("123", str(123));
+    ASSERT_EQ("-456", str(-456));
 
     // floating point
-    ASSERT_EQ("12.75", fmt::str(12.75));
-    ASSERT_EQ("-2.25", fmt::str(-2.25));
+    ASSERT_EQ("12.75", str(12.75));
+    ASSERT_EQ("-2.25", str(-2.25));
 }
 
 TEST(Formatting, WithFunction) {
-    using fmt::with;
-    using fmt::ff;
-
-    auto f = fmt::fixed().precision(2);
-    auto sf1 = fmt::str(with(123, f));
+    auto f = fixed().precision(2);
+    auto sf1 = str(with(123, f));
     ASSERT_EQ("123.00", sf1);
 
-    auto wfe = fmt::str(with(123, ff(5)));
+    auto wfe = str(with(123, ff(5)));
     ASSERT_EQ("  123", wfe);
 
-    auto wfe_r = fmt::str(with(123, ff(5, false)));
+    auto wfe_r = str(with(123, ff(5, false)));
     ASSERT_EQ("  123", wfe_r);
 
-    auto wfe_l = fmt::str(with(123, ff(5, true)));
+    auto wfe_l = str(with(123, ff(5, true)));
     ASSERT_EQ("123  ", wfe_l);
 
-    auto sfe = fmt::str(with(123, f | ff(8)));
+    auto sfe = str(with(123, f | ff(8)));
     ASSERT_EQ("  123.00", sfe);
 
-    auto sfe_r = fmt::str(with(123, f | ff(8, false)));
+    auto sfe_r = str(with(123, f | ff(8, false)));
     ASSERT_EQ("  123.00", sfe_r);
 
-    auto sfe_l = fmt::str(with(123, f | ff(8, true)));
+    auto sfe_l = str(with(123, f | ff(8, true)));
     ASSERT_EQ("123.00  ", sfe_l);
 }
 
 TEST(Formatting, StrConcat) {
-    using fmt::ff;
+    ASSERT_EQ("", str());
+    ASSERT_EQ("123", str(123));
+    ASSERT_EQ("abc.xyz", str("abc", ".xyz"));
+    ASSERT_EQ("abc.xyz", str("abc", '.', "xyz"));
+    ASSERT_EQ("1+2 = 3", str(1, '+', 2, " = ", 3));
 
-    ASSERT_EQ("", fmt::str());
-    ASSERT_EQ("123", fmt::str(123));
-    ASSERT_EQ("abc.xyz", fmt::str("abc", ".xyz"));
-    ASSERT_EQ("abc.xyz", fmt::str("abc", '.', "xyz"));
-    ASSERT_EQ("1+2 = 3", fmt::str(1, '+', 2, " = ", 3));
-
-    auto f = fmt::fixed().precision(2);
-    auto sf2 = fmt::str(with(123, f), with(456, f));
+    auto f = fixed().precision(2);
+    auto sf2 = str(with(123, f), with(456, f));
     ASSERT_EQ("123.00456.00", sf2);
 
-    auto sf3 = fmt::str(with(123, f), ", ", '~', with(456, f | ff(8)));
+    auto sf3 = str(with(123, f), ", ", '~', with(456, f | ff(8)));
     ASSERT_EQ("123.00, ~  456.00", sf3);
 }

--- a/tests/test_formatting.cpp
+++ b/tests/test_formatting.cpp
@@ -17,13 +17,15 @@ TEST(Formatting, Csprintf) {
 
 template<class T, class Fmt>
 void test_formatter(const T& x, const Fmt& f, const std::string& refstr) {
+    using fmt::ff;
+
     const size_t buf_len = 128;
     static char buf[buf_len];
 
-    size_t flen = f.max_formatted_length(x);
+    size_t flen = f(x, static_cast<char*>(nullptr), 0);
     ASSERT_LT(flen, 100);
 
-    size_t wlen = f.formatted_write(x, buf, flen + 1);
+    size_t wlen = f(x, buf, flen + 1);
     ASSERT_EQ(flen, wlen);
 
     std::string s(buf);
@@ -35,12 +37,12 @@ void test_formatter(const T& x, const Fmt& f, const std::string& refstr) {
         size_t expect_wlen = (std::max)(flen, w);
         std::string pad = w > flen ? std::string(w - flen, ' ') : std::string();
 
-        wlen = f.formatted_write(x, w, false, buf, buf_len);
+        wlen = f.field_write(x, ff(w, false), buf, buf_len);
         std::string s_r(buf);
         ASSERT_EQ(expect_wlen, wlen);
         ASSERT_EQ(pad + s, s_r);
 
-        wlen = f.formatted_write(x, w, true, buf, buf_len);
+        wlen = f.field_write(x, ff(w, true), buf, buf_len);
         std::string s_l(buf);
         ASSERT_EQ(expect_wlen, wlen);
         ASSERT_EQ(s + pad, s_l);
@@ -53,14 +55,13 @@ TEST(Formatting, DefaultBoolFmt) {
 }
 
 TEST(Formatting, DefaultCharFmt) {
-    test_formatter('a', fmt::default_char_formatter{}, "a");
+    test_formatter('a', fmt::default_char_formatter<char>{}, "a");
 }
 
-
 void test_default_string_formatter(const std::string& src) {
-    test_formatter(src, fmt::default_string_formatter{}, src);
-    test_formatter(string_view(src), fmt::default_string_formatter{}, src);
-    test_formatter(src.c_str(), fmt::default_string_formatter{}, src);
+    test_formatter(src, fmt::default_string_formatter<char>{}, src);
+    test_formatter(string_view(src), fmt::default_string_formatter<char>{}, src);
+    test_formatter(src.c_str(), fmt::default_string_formatter<char>{}, src);
 }
 
 TEST(Formatting, DefaultStringFmt) {

--- a/tests/test_formatting.cpp
+++ b/tests/test_formatting.cpp
@@ -94,31 +94,34 @@ TEST(Formatting, FmtStr) {
 
 TEST(Formatting, WithFunction) {
     using fmt::with;
+    using fmt::ff;
 
     auto f = fmt::fixed().precision(2);
     auto sf1 = fmt::str(with(123, f));
     ASSERT_EQ("123.00", sf1);
 
-    auto wfe = fmt::str(with(123, 5));
+    auto wfe = fmt::str(with(123, ff(5)));
     ASSERT_EQ("  123", wfe);
 
-    auto wfe_r = fmt::str(with(123, 5, false));
+    auto wfe_r = fmt::str(with(123, ff(5, false)));
     ASSERT_EQ("  123", wfe_r);
 
-    auto wfe_l = fmt::str(with(123, 5, true));
+    auto wfe_l = fmt::str(with(123, ff(5, true)));
     ASSERT_EQ("123  ", wfe_l);
 
-    auto sfe = fmt::str(with(123, f, 8));
+    auto sfe = fmt::str(with(123, f | ff(8)));
     ASSERT_EQ("  123.00", sfe);
 
-    auto sfe_r = fmt::str(with(123, f, 8, false));
+    auto sfe_r = fmt::str(with(123, f | ff(8, false)));
     ASSERT_EQ("  123.00", sfe_r);
 
-    auto sfe_l = fmt::str(with(123, f, 8, true));
+    auto sfe_l = fmt::str(with(123, f | ff(8, true)));
     ASSERT_EQ("123.00  ", sfe_l);
 }
 
 TEST(Formatting, StrConcat) {
+    using fmt::ff;
+
     ASSERT_EQ("", fmt::str());
     ASSERT_EQ("123", fmt::str(123));
     ASSERT_EQ("abc.xyz", fmt::str("abc", ".xyz"));
@@ -129,6 +132,6 @@ TEST(Formatting, StrConcat) {
     auto sf2 = fmt::str(with(123, f), with(456, f));
     ASSERT_EQ("123.00456.00", sf2);
 
-    auto sf3 = fmt::str(with(123, f), ", ", '~', with(456, f, 8));
+    auto sf3 = fmt::str(with(123, f), ", ", '~', with(456, f | ff(8)));
     ASSERT_EQ("123.00, ~  456.00", sf3);
 }

--- a/tests/test_formatting.cpp
+++ b/tests/test_formatting.cpp
@@ -35,12 +35,12 @@ void test_formatter(const T& x, const Fmt& f, const std::string& refstr) {
         size_t expect_wlen = (std::max)(flen, w);
         std::string pad = w > flen ? std::string(w - flen, ' ') : std::string();
 
-        wlen = f.field_write(x, ff(w, false), buf, buf_len);
+        wlen = f.field_write(x, align_right(w), buf, buf_len);
         std::string s_r(buf);
         ASSERT_EQ(expect_wlen, wlen);
         ASSERT_EQ(pad + s, s_r);
 
-        wlen = f.field_write(x, ff(w, true), buf, buf_len);
+        wlen = f.field_write(x, align_left(w), buf, buf_len);
         std::string s_l(buf);
         ASSERT_EQ(expect_wlen, wlen);
         ASSERT_EQ(s + pad, s_l);
@@ -96,22 +96,16 @@ TEST(Formatting, WithFunction) {
     auto sf1 = str(withf(123, f));
     ASSERT_EQ("123.00", sf1);
 
-    auto wfe = str(withf(123, ff(5)));
-    ASSERT_EQ("  123", wfe);
-
-    auto wfe_r = str(withf(123, ff(5, false)));
+    auto wfe_r = str(withf(123, align_right(5)));
     ASSERT_EQ("  123", wfe_r);
 
-    auto wfe_l = str(withf(123, ff(5, true)));
+    auto wfe_l = str(withf(123, align_left(5)));
     ASSERT_EQ("123  ", wfe_l);
 
-    auto sfe = str(withf(123, f | ff(8)));
-    ASSERT_EQ("  123.00", sfe);
-
-    auto sfe_r = str(withf(123, f | ff(8, false)));
+    auto sfe_r = str(withf(123, f | align_right(8)));
     ASSERT_EQ("  123.00", sfe_r);
 
-    auto sfe_l = str(withf(123, f | ff(8, true)));
+    auto sfe_l = str(withf(123, f | align_left(8)));
     ASSERT_EQ("123.00  ", sfe_l);
 }
 
@@ -126,6 +120,6 @@ TEST(Formatting, StrConcat) {
     auto sf2 = str(withf(123, f), withf(456, f));
     ASSERT_EQ("123.00456.00", sf2);
 
-    auto sf3 = str(withf(123, f), ", ", '~', withf(456, f | ff(8)));
+    auto sf3 = str(withf(123, f), ", ", '~', withf(456, f | align_right(8)));
     ASSERT_EQ("123.00, ~  456.00", sf3);
 }

--- a/tests/test_formatting.cpp
+++ b/tests/test_formatting.cpp
@@ -93,25 +93,25 @@ TEST(Formatting, FmtStr) {
 
 TEST(Formatting, WithFunction) {
     auto f = fixed().precision(2);
-    auto sf1 = str(with(123, f));
+    auto sf1 = str(withf(123, f));
     ASSERT_EQ("123.00", sf1);
 
-    auto wfe = str(with(123, ff(5)));
+    auto wfe = str(withf(123, ff(5)));
     ASSERT_EQ("  123", wfe);
 
-    auto wfe_r = str(with(123, ff(5, false)));
+    auto wfe_r = str(withf(123, ff(5, false)));
     ASSERT_EQ("  123", wfe_r);
 
-    auto wfe_l = str(with(123, ff(5, true)));
+    auto wfe_l = str(withf(123, ff(5, true)));
     ASSERT_EQ("123  ", wfe_l);
 
-    auto sfe = str(with(123, f | ff(8)));
+    auto sfe = str(withf(123, f | ff(8)));
     ASSERT_EQ("  123.00", sfe);
 
-    auto sfe_r = str(with(123, f | ff(8, false)));
+    auto sfe_r = str(withf(123, f | ff(8, false)));
     ASSERT_EQ("  123.00", sfe_r);
 
-    auto sfe_l = str(with(123, f | ff(8, true)));
+    auto sfe_l = str(withf(123, f | ff(8, true)));
     ASSERT_EQ("123.00  ", sfe_l);
 }
 
@@ -123,9 +123,9 @@ TEST(Formatting, StrConcat) {
     ASSERT_EQ("1+2 = 3", str(1, '+', 2, " = ", 3));
 
     auto f = fixed().precision(2);
-    auto sf2 = str(with(123, f), with(456, f));
+    auto sf2 = str(withf(123, f), withf(456, f));
     ASSERT_EQ("123.00456.00", sf2);
 
-    auto sf3 = str(with(123, f), ", ", '~', with(456, f | ff(8)));
+    auto sf3 = str(withf(123, f), ", ", '~', withf(456, f | ff(8)));
     ASSERT_EQ("123.00, ~  456.00", sf3);
 }

--- a/tests/test_include_all.cpp
+++ b/tests/test_include_all.cpp
@@ -9,8 +9,8 @@
 using clue::array_view;
 
 // formatting
-using clue::fmt::with;
-using clue::fmt::str;
+using clue::with;
+using clue::str;
 
 // meta
 using clue::meta::type_;
@@ -19,8 +19,8 @@ using clue::meta::type_;
 using clue::meta::seq_;
 
 // numformat
-using clue::fmt::int_formatter;
-using clue::fmt::float_formatter;
+using clue::int_formatter;
+using clue::float_formatter;
 
 // optional
 using clue::optional;

--- a/tests/test_include_all.cpp
+++ b/tests/test_include_all.cpp
@@ -9,7 +9,7 @@
 using clue::array_view;
 
 // formatting
-using clue::with;
+using clue::withf;
 using clue::str;
 
 // meta

--- a/tests/test_numformat.cpp
+++ b/tests/test_numformat.cpp
@@ -19,12 +19,12 @@ std::string ref_int_format(const F& f, size_t width, bool ljust, long x) {
     if (x < 0) {
         *p++ = '-';
         if (pw > 0) pw--;
-    } else if (f.any(fmt_flag_t::showpos)) {
+    } else if (f.any(fmt::showpos)) {
         *p++ = '+';
         if (pw > 0) pw--;
     }
 
-    bool pzeros = f.any(fmt_flag_t::padzeros);
+    bool pzeros = f.any(fmt::padzeros);
     if (ljust) pzeros = false;
 
     *p++ = '%';
@@ -41,7 +41,7 @@ std::string ref_int_format(const F& f, size_t width, bool ljust, long x) {
     *p++ = 'l';
     switch (f.base()) {
         case 8: *p++ = 'o'; break;
-        case 16: *p++ = f.any(fmt_flag_t::uppercase) ? 'X' : 'x'; break;
+        case 16: *p++ = f.any(fmt::uppercase) ? 'X' : 'x'; break;
         default: *p++ = 'u';
     }
     *p = '\0';
@@ -72,8 +72,8 @@ template<typename T, typename F>
             << "Mismatched formatted length for "
             << " x = " << x << ":\n"
             << "  base: " << f.base() << "\n"
-            << "  showpos: " << f.any(fmt_flag_t::showpos) << "\n"
-            << "  padzeros: " << f.any(fmt_flag_t::padzeros) << "\n"
+            << "  showpos: " << f.any(fmt::showpos) << "\n"
+            << "  padzeros: " << f.any(fmt::padzeros) << "\n"
             << "Result:\n"
             << "  ACTUAL = " << flen << "\n"
             << "  EXPECT = " << refstr.size()
@@ -89,8 +89,8 @@ template<typename T, typename F>
             << "Mismatched formatted string for "
             << " x = " << x << ":\n"
             << "  base: " << f.base() << "\n"
-            << "  showpos: " << f.any(fmt_flag_t::showpos) << "\n"
-            << "  padzeros: " << f.any(fmt_flag_t::padzeros) << "\n"
+            << "  showpos: " << f.any(fmt::showpos) << "\n"
+            << "  padzeros: " << f.any(fmt::padzeros) << "\n"
             << "Result:\n"
             << "  ACTUAL = \"" << r << "\"\n"
             << "  EXPECT = \"" << refstr << "\"";
@@ -118,8 +118,8 @@ template<typename T, typename F>
             << " x = " << x << ":\n"
             << "  pos: " << ffmt.width() << ", " << ffmt.leftjust() << "\n"
             << "  base: " << f.base() << "\n"
-            << "  showpos: " << f.any(fmt_flag_t::showpos) << "\n"
-            << "  padzeros: " << f.any(fmt_flag_t::padzeros) << "\n"
+            << "  showpos: " << f.any(fmt::showpos) << "\n"
+            << "  padzeros: " << f.any(fmt::padzeros) << "\n"
             << "Result:\n"
             << "  ACTUAL = \"" << r << "\"\n"
             << "  EXPECT = \"" << refstr << "\"";
@@ -176,8 +176,8 @@ std::vector<long> prepare_test_ints(size_t base, bool show=false) {
 template<class F>
 void test_int_fmt(const F& f, unsigned base_, bool padzeros_, bool showpos_) {
     ASSERT_EQ(base_, f.base());
-    ASSERT_EQ(padzeros_, f.any(fmt_flag_t::padzeros));
-    ASSERT_EQ(showpos_,  f.any(fmt_flag_t::showpos));
+    ASSERT_EQ(padzeros_, f.any(fmt::padzeros));
+    ASSERT_EQ(showpos_,  f.any(fmt::showpos));
 
     // combination coverage
     std::vector<size_t> widths = {0, 4, 8, 12, 20, 26};
@@ -198,9 +198,9 @@ void test_int_fmt(const F& f, unsigned base_, bool padzeros_, bool showpos_) {
 template<class F>
 void test_int_fmt_x(const F& fbase, unsigned base_) {
     test_int_fmt(fbase, base_, false, false);
-    test_int_fmt(fbase | fmt_flag_t::showpos,  base_, false, true);
-    test_int_fmt(fbase | fmt_flag_t::padzeros, base_, true, false);
-    test_int_fmt(fbase | fmt_flag_t::padzeros | fmt_flag_t::showpos, base_, true, true);
+    test_int_fmt(fbase | fmt::showpos,  base_, false, true);
+    test_int_fmt(fbase | fmt::padzeros, base_, true, false);
+    test_int_fmt(fbase | fmt::padzeros | fmt::showpos, base_, true, true);
 }
 
 
@@ -221,7 +221,7 @@ TEST(IntFmt, HexFmt) {
 }
 
 TEST(IntFmt, UHexFmt) {
-    test_int_fmt_x(hex() | fmt_flag_t::uppercase, 16);
+    test_int_fmt_x(hex() | fmt::uppercase, 16);
 }
 
 
@@ -232,10 +232,10 @@ TEST(IntFmt, UHexFmt) {
 //=====================================
 
 inline char notation(const fixed_formatter& f) {
-    return f.any(fmt_flag_t::uppercase) ? 'F' : 'f';
+    return f.any(fmt::uppercase) ? 'F' : 'f';
 }
 inline char notation(const sci_formatter& f)   {
-    return f.any(fmt_flag_t::uppercase) ? 'E' : 'e';
+    return f.any(fmt::uppercase) ? 'E' : 'e';
 }
 
 template<class F>
@@ -245,9 +245,9 @@ std::string ref_float_format(const F& f, size_t width, bool ljust, double x) {
     char cfmt[16];
     char *p = cfmt;
     *p++ = '%';
-    if (f.any(fmt_flag_t::showpos)) *p++ = '+';
+    if (f.any(fmt::showpos)) *p++ = '+';
     if (ljust) *p++ = '-';
-    else if (f.any(fmt_flag_t::padzeros)) *p++ = '0';
+    else if (f.any(fmt::padzeros)) *p++ = '0';
 
     if (pw > 0) {
         if (pw >= 10) {
@@ -288,8 +288,8 @@ template<typename T, typename F>
             << "x = " << x << ": \n"
             << "  notation: " << notation(f) << "\n"
             << "  precision: " << f.precision() << "\n"
-            << "  showpos: " << f.any(fmt_flag_t::showpos) << "\n"
-            << "  padzeros: " << f.any(fmt_flag_t::padzeros) << "\n"
+            << "  showpos: " << f.any(fmt::showpos) << "\n"
+            << "  padzeros: " << f.any(fmt::padzeros) << "\n"
             << "Result:\n"
             << "  ACTUAL = " << flen << "\n"
             << "  EXPECT = " << refstr.length()
@@ -306,8 +306,8 @@ template<typename T, typename F>
             << "x = " << x << ": \n"
             << "  notation: " << notation(f) << "\n"
             << "  precision: " << f.precision() << "\n"
-            << "  showpos: " << f.any(fmt_flag_t::showpos) << "\n"
-            << "  padzeros: " << f.any(fmt_flag_t::padzeros) << "\n"
+            << "  showpos: " << f.any(fmt::showpos) << "\n"
+            << "  padzeros: " << f.any(fmt::padzeros) << "\n"
             << "Result:\n"
             << "  ACTUAL = \"" << r << "\"\n"
             << "  EXPECT = \"" << refstr << "\"";
@@ -335,8 +335,8 @@ template<typename T, typename F>
             << "  pos: " << ffmt.width() << ", " << ffmt.leftjust() << "\n"
             << "  notation: " << notation(f) << "\n"
             << "  precision: " << f.precision() << "\n"
-            << "  showpos: " << f.any(fmt_flag_t::showpos) << "\n"
-            << "  padzeros: " << f.any(fmt_flag_t::padzeros) << "\n"
+            << "  showpos: " << f.any(fmt::showpos) << "\n"
+            << "  padzeros: " << f.any(fmt::padzeros) << "\n"
             << "Result:\n"
             << "  ACTUAL = \"" << r << "\"\n"
             << "  EXPECT = \"" << refstr << "\"";
@@ -376,9 +376,9 @@ std::vector<double> prepare_test_floats() {
 template<class F>
 void test_float_fmt(const F& f, size_t prec, bool upper_, bool padzeros_, bool showpos_) {
     ASSERT_EQ(prec, f.precision());
-    ASSERT_EQ(upper_, f.any(fmt_flag_t::uppercase));
-    ASSERT_EQ(padzeros_, f.any(fmt_flag_t::padzeros));
-    ASSERT_EQ(showpos_,  f.any(fmt_flag_t::showpos));
+    ASSERT_EQ(upper_, f.any(fmt::uppercase));
+    ASSERT_EQ(padzeros_, f.any(fmt::padzeros));
+    ASSERT_EQ(showpos_,  f.any(fmt::showpos));
 
     // combination coverage
     std::vector<size_t> widths = {0, 5, 12};
@@ -403,14 +403,14 @@ void test_float_fmt_x(const F& fbase) {
 
     for(size_t prec: precisions) {
         auto f000 = fbase.precision(prec);
-        auto f001 = f000 | fmt_flag_t::showpos;
-        auto f010 = f000 | fmt_flag_t::padzeros;
-        auto f011 = f000 | fmt_flag_t::showpos | fmt_flag_t::padzeros;
+        auto f001 = f000 | fmt::showpos;
+        auto f010 = f000 | fmt::padzeros;
+        auto f011 = f000 | fmt::showpos | fmt::padzeros;
 
-        auto f100 = fbase.precision(prec) | fmt_flag_t::uppercase;
-        auto f101 = f100 | fmt_flag_t::showpos;
-        auto f110 = f100 | fmt_flag_t::padzeros;
-        auto f111 = f100 | fmt_flag_t::showpos | fmt_flag_t::padzeros;
+        auto f100 = fbase.precision(prec) | fmt::uppercase;
+        auto f101 = f100 | fmt::showpos;
+        auto f110 = f100 | fmt::padzeros;
+        auto f111 = f100 | fmt::showpos | fmt::padzeros;
 
         test_float_fmt(f000, prec, false, false, false);
         test_float_fmt(f001, prec, false, false,  true);

--- a/tests/test_numformat.cpp
+++ b/tests/test_numformat.cpp
@@ -185,11 +185,11 @@ void test_int_fmt(const F& f, unsigned base_, bool padzeros_, bool showpos_) {
     std::vector<long> xs = prepare_test_ints(base_);
     for (long x: xs) {
         for (size_t w: widths) {
-            auto wfmt_0 = with(x, f);
+            auto wfmt_0 = withf(x, f);
             ASSERT_PRED_FORMAT1(CheckIntFormat, wfmt_0);
-            auto wfmt_r = with(x, f | ff(w, false));
+            auto wfmt_r = withf(x, f | ff(w, false));
             ASSERT_PRED_FORMAT1(CheckIntFormat, wfmt_r);
-            auto wfmt_l = with(x, f | ff(w, true));
+            auto wfmt_l = withf(x, f | ff(w, true));
             ASSERT_PRED_FORMAT1(CheckIntFormat, wfmt_l);
         }
     }
@@ -386,11 +386,11 @@ void test_float_fmt(const F& f, size_t prec, bool upper_, bool padzeros_, bool s
     std::vector<double> xs = prepare_test_floats();
     for (long x: xs) {
         for (size_t w: widths) {
-            auto wfmt_0 = with(x, f);
+            auto wfmt_0 = withf(x, f);
             ASSERT_PRED_FORMAT1(CheckFloatFormat, wfmt_0);
-            auto wfmt_r = with(x, f | ff(w, false));
+            auto wfmt_r = withf(x, f | ff(w, false));
             ASSERT_PRED_FORMAT1(CheckFloatFormat, wfmt_r);
-            auto wfmt_l = with(x, f | ff(w, true));
+            auto wfmt_l = withf(x, f | ff(w, true));
             ASSERT_PRED_FORMAT1(CheckFloatFormat, wfmt_l);
         }
     }

--- a/tests/test_numformat.cpp
+++ b/tests/test_numformat.cpp
@@ -187,9 +187,9 @@ void test_int_fmt(const F& f, unsigned base_, bool padzeros_, bool showpos_) {
         for (size_t w: widths) {
             auto wfmt_0 = withf(x, f);
             ASSERT_PRED_FORMAT1(CheckIntFormat, wfmt_0);
-            auto wfmt_r = withf(x, f | ff(w, false));
+            auto wfmt_r = withf(x, f | align_right(w));
             ASSERT_PRED_FORMAT1(CheckIntFormat, wfmt_r);
-            auto wfmt_l = withf(x, f | ff(w, true));
+            auto wfmt_l = withf(x, f | align_left(w));
             ASSERT_PRED_FORMAT1(CheckIntFormat, wfmt_l);
         }
     }
@@ -388,9 +388,9 @@ void test_float_fmt(const F& f, size_t prec, bool upper_, bool padzeros_, bool s
         for (size_t w: widths) {
             auto wfmt_0 = withf(x, f);
             ASSERT_PRED_FORMAT1(CheckFloatFormat, wfmt_0);
-            auto wfmt_r = withf(x, f | ff(w, false));
+            auto wfmt_r = withf(x, f | align_right(w));
             ASSERT_PRED_FORMAT1(CheckFloatFormat, wfmt_r);
-            auto wfmt_l = withf(x, f | ff(w, true));
+            auto wfmt_l = withf(x, f | align_left(w));
             ASSERT_PRED_FORMAT1(CheckFloatFormat, wfmt_l);
         }
     }
@@ -454,7 +454,7 @@ void test_exact_float_fmt(const F& f) {
         }
 
         for (size_t w: widths) {
-            f.field_write(x, ff(w, false), buf, buf_len);
+            f.field_write(x, align_right(w), buf, buf_len);
             std::string s_r(buf);
             if (w <= l0) {
                 ASSERT_EQ(s0, s_r);
@@ -462,7 +462,7 @@ void test_exact_float_fmt(const F& f) {
                 ASSERT_EQ(std::string(w - l0, ' ') + s0, s_r);
             }
 
-            f.field_write(x, ff(w, true), buf, buf_len);
+            f.field_write(x, align_left(w), buf, buf_len);
             std::string s_l(buf);
             if (w <= l0) {
                 ASSERT_EQ(s0, s_l);

--- a/tests/test_string_builder.cpp
+++ b/tests/test_string_builder.cpp
@@ -137,10 +137,16 @@ TEST(StringBuilder, WriteSeq) {
 
     ASSERT_EQ("1+2=3\n4 + 5 = 9\n", sb.str());
 
+    // without `with` helper, one has to write so much ...
+    using with_fixed = fmt::with_fmt_t<int, fmt::fixed_formatter>;
+    using with_sci = fmt::with_fmt_t<double, fmt::sci_formatter>;
+    using fchar_t = fmt::field_formatter<fmt::default_char_formatter>;
+    using with_fchar = fmt::with_fmt_t<char, fchar_t>;
+
     sb.clear();
-    sb << fmt::with(1, fmt::fixed().precision(4) ) << ", "
-       << fmt::with(2.5, fmt::sci().precision(3) ) << ", "
-       << "'" << fmt::with('a', fmt::default_char_formatter{}, 3) << "'";
+    sb << with_fixed{ 1, fmt::fixed().precision(4) } << ", "
+       << with_sci{ 2.5, fmt::sci().precision(3) } << ", "
+       << "'" << with_fchar{ 'a', fchar_t{fmt::default_char_formatter{}, fmt::ff(3)} } << "'";
 
     ASSERT_EQ("1.0000, 2.500e+00, '  a'", sb.str());
 }

--- a/tests/test_string_builder.cpp
+++ b/tests/test_string_builder.cpp
@@ -147,7 +147,7 @@ TEST(StringBuilder, WriteSeq) {
     sb.clear();
     sb << with_fixed{ 1, fixed().precision(4) } << ", "
        << with_sci{ 2.5, sci().precision(3) } << ", "
-       << "'" << with_fchar{ 'a', fchar_t{char_fmt{}, ff(3)} } << "'";
+       << "'" << with_fchar{ 'a', fchar_t{char_fmt{}, align_right(3)} } << "'";
 
     ASSERT_EQ("1.0000, 2.500e+00, '  a'", sb.str());
 }

--- a/tests/test_string_builder.cpp
+++ b/tests/test_string_builder.cpp
@@ -140,13 +140,14 @@ TEST(StringBuilder, WriteSeq) {
     // without `with` helper, one has to write so much ...
     using with_fixed = fmt::with_fmt_t<int, fmt::fixed_formatter>;
     using with_sci = fmt::with_fmt_t<double, fmt::sci_formatter>;
-    using fchar_t = fmt::field_formatter<fmt::default_char_formatter>;
+    using char_fmt = fmt::default_char_formatter<char>;
+    using fchar_t = fmt::field_formatter<char_fmt>;
     using with_fchar = fmt::with_fmt_t<char, fchar_t>;
 
     sb.clear();
     sb << with_fixed{ 1, fmt::fixed().precision(4) } << ", "
        << with_sci{ 2.5, fmt::sci().precision(3) } << ", "
-       << "'" << with_fchar{ 'a', fchar_t{fmt::default_char_formatter{}, fmt::ff(3)} } << "'";
+       << "'" << with_fchar{ 'a', fchar_t{char_fmt{}, fmt::ff(3)} } << "'";
 
     ASSERT_EQ("1.0000, 2.500e+00, '  a'", sb.str());
 }

--- a/tests/test_string_builder.cpp
+++ b/tests/test_string_builder.cpp
@@ -138,16 +138,16 @@ TEST(StringBuilder, WriteSeq) {
     ASSERT_EQ("1+2=3\n4 + 5 = 9\n", sb.str());
 
     // without `with` helper, one has to write so much ...
-    using with_fixed = fmt::with_fmt_t<int, fmt::fixed_formatter>;
-    using with_sci = fmt::with_fmt_t<double, fmt::sci_formatter>;
-    using char_fmt = fmt::default_char_formatter<char>;
-    using fchar_t = fmt::field_formatter<char_fmt>;
-    using with_fchar = fmt::with_fmt_t<char, fchar_t>;
+    using with_fixed = with_fmt_t<int, fixed_formatter>;
+    using with_sci = with_fmt_t<double, sci_formatter>;
+    using char_fmt = default_char_formatter<char>;
+    using fchar_t = field_formatter<char_fmt>;
+    using with_fchar = with_fmt_t<char, fchar_t>;
 
     sb.clear();
-    sb << with_fixed{ 1, fmt::fixed().precision(4) } << ", "
-       << with_sci{ 2.5, fmt::sci().precision(3) } << ", "
-       << "'" << with_fchar{ 'a', fchar_t{char_fmt{}, fmt::ff(3)} } << "'";
+    sb << with_fixed{ 1, fixed().precision(4) } << ", "
+       << with_sci{ 2.5, sci().precision(3) } << ", "
+       << "'" << with_fchar{ 'a', fchar_t{char_fmt{}, ff(3)} } << "'";
 
     ASSERT_EQ("1.0000, 2.500e+00, '  a'", sb.str());
 }


### PR DESCRIPTION
When working with other projects, I found that the current formatting framework is still too cumbersome to extend. 

This PR substantially simplify the the interface of formatter, thus making it much simpler to write a new formatter and designating a default formatter for a user type.

Now, writing a formatter is basically just like writing a functor, and to designate a default formatter, one just have to overload ``get_default_formatter``.

Also field specification becomes much more explicit, consistent, and readable. Instead of ``with(x, fmter, width, leftjust)``, now we write ``withf(x, fmter | align_left(w))`` or ``withf(x, fmter | align_right(w))``. 

This refactoring leads to 200+ lines reduction.
