### PR TITLE
Add ordered_dict class template

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,7 @@ set(UNIT_TESTS
     test_value_range
     test_array_view
     test_reindexed_view
+    test_ordered_dict
     test_meta
     test_meta_seq
     test_textio

--- a/doc/source/array_view.rst
+++ b/doc/source/array_view.rst
@@ -47,7 +47,7 @@ In practice, it is not uncommon that you maintain a vector in your object and wo
 The ``array_view`` class template
 -----------------------------------
 
-.. cpp:class:: array_view<T>
+.. cpp:class:: template<T> array_view<T>
 
     :param T: The element type.
 

--- a/doc/source/ordered_dict.rst
+++ b/doc/source/ordered_dict.rst
@@ -1,0 +1,44 @@
+Ordered Dict
+=============
+
+An *ordered dict* is an associative container (like a hash table) that preserves the input order of the entries,
+namely, the order of pairs that one visits when traversing from ``begin()`` to ``end()`` is the same as
+the order of those pairs being inserted to the dict.
+
+.. note::
+
+    The order-preserving behavior is similar to that of
+    `Python's OrderedDict <https://docs.python.org/2/library/collections.html#collections.OrderedDict>`_.
+
+.. code-block:: cpp
+
+    #include <clue/ordered_dict.hpp>
+
+    using namespace clue;
+
+    ordered_dict<string, int> d;
+    d["a"] = 1;
+    d["b"] = 3;
+    d["c"] = 2;
+
+    for (const auto& e: d) {
+        std::cout << e.first << " -- " << e.second << std::endl;
+    }
+
+    // This snippet prints:
+    //
+    // a -- 1
+    // b -- 2
+    // c -- 3
+
+
+The ``ordered_dict`` class template
+------------------------------------
+
+.. cpp:class:: ordered_dict<Key, T, Hash, KeyEqual, Allocator>
+
+    :param Key:  The Key type.
+    :param T:    The mapped type.
+    :param Hash: The hash functor type.
+    :param KeyEqual: The functor type for key equality comparison.
+    :param Allocator: The allocator type.

--- a/include/clue/ordered_dict.hpp
+++ b/include/clue/ordered_dict.hpp
@@ -120,6 +120,14 @@ public:
         return vec_[map_.at(key)].second;
     }
 
+    value_type& at_pos(size_type pos) {
+        return vec_.at(pos);
+    }
+
+    const value_type& at_pos(size_type pos) const {
+        return vec_.at(pos);
+    }
+
     T& operator[](const Key& key) {
         return try_emplace(key).first->second;
     }

--- a/include/clue/ordered_dict.hpp
+++ b/include/clue/ordered_dict.hpp
@@ -1,0 +1,184 @@
+/**
+ * @file ordered_dict.hpp
+ *
+ * The ordered_dict class, which provides an interface similar to
+ * that of std::unordered_map but maintains the input order of pairs.
+ */
+
+#ifndef CLUE_ORDERED_DICT__
+#define CLUE_ORDERED_DICT__
+
+#include <clue/container_common.hpp>
+#include <vector>
+#include <unordered_map>
+
+namespace clue {
+
+template<class Key,
+         class T,
+         class Hash = std::hash<T>,
+         class KeyEqual = std::equal_to<Key>,
+         class Allocator = std::allocator< std::pair<Key,T> >
+        >
+class ordered_dict {
+private:
+    using vector_type = std::vector< std::pair<Key, T>, Allocator >;
+
+    using map_entry = std::pair<Key, size_t>;
+    using map_allocator = typename Allocator::template rebind<map_entry>::other;
+    using map_type = std::unordered_map<Key, size_t, Hash, KeyEqual, map_allocator>;
+
+public:
+    // type names
+    using key_type = Key;
+    using mapped_type = T;
+    using value_type = std::pair<Key, T>;
+    using size_type = size_t;
+    using difference_type = ptrdiff_t;
+    using hasher = Hash;
+    using key_equal = KeyEqual;
+    using allocator_type = Allocator;
+
+    using reference = value_type&;
+    using const_reference = const value_type&;
+    using pointer = typename std::allocator_traits<Allocator>::pointer;
+    using const_pointer = typename std::allocator_traits<Allocator>::const_pointer;
+    using iterator = typename vector_type::iterator;
+    using const_iterator = typename vector_type::const_iterator;
+
+private:
+    vector_type vec_;
+    map_type map_;
+
+public:
+    bool empty() const noexcept {
+        return vec_.empty();
+    }
+
+    size_t size() const noexcept {
+        return vec_.size();
+    }
+
+    size_t max_size() const noexcept {
+        return vec_.max_size();
+    }
+
+    iterator begin() { return vec_.begin(); }
+    iterator end()   { return vec_.end(); }
+
+    const_iterator begin() const { return vec_.begin(); }
+    const_iterator end()   const { return vec_.end(); }
+
+    const_iterator cbegin() const { return vec_.cbegin(); }
+    const_iterator cend()   const { return vec_.cend(); }
+
+    T& at(const Key& key) {
+        return map_.at(key).second;
+    }
+
+    const T& at(const Key& key) const {
+        return map_.at(key).second;
+    }
+
+    T& operator[](const Key& key) {
+        return try_emplace(key).first->second.second;
+    }
+
+    T& operator[](Key&& key) {
+        return try_emplace(std::move(key)).first->second.second;
+    }
+
+    iterator find(const Key& key) {
+        auto it = map_.find(key);
+        return it == map_.end() ?
+            vec_.end() : vec_.begin() + it->second;
+    }
+
+    const_iterator find(const Key& key) const {
+        auto it = map_.find(key);
+        return it == map_.end() ?
+            vec_.end() : vec_.begin() + it->second;
+    }
+
+    size_type count(const Key& key) const {
+        return map_.count(key);
+    }
+
+public:
+    void clear() {
+        map_.clear();
+        vec_.clear();
+    }
+
+    template<class... Args>
+    std::pair<iterator, bool> emplace(Args&&... args) {
+        value_type v(std::forward<Args>(args)...);
+        auto it = map_.find(v.first);
+        if (it == map_.end()) {
+            vec_.emplace_back(std::move(v));
+            return _post_insert();
+        } else {
+            return std::make_pair(it, false);
+        }
+    }
+
+    template<class... Args>
+    std::pair<iterator, bool> try_emplace(const key_type& k, Args&&... args) {
+        auto it = map_.find(k);
+        if (it == map_.end()) {
+            vec_.emplace_back(std::piecewise_construct,
+                              std::forward_as_tuple(k),
+                              std::forward_as_tuple(std::forward<Args>(args)...));
+            return _post_insert();
+        } else {
+            return std::make_pair(it, false);
+        }
+    }
+
+    std::pair<iterator, bool> insert(const value_type& v) {
+        auto it = map_.find(v.first);
+        if (it == map_.end()) {
+            vec_.emplace_back(v);
+            return _post_insert();
+        } else {
+            return std::make_pair(it, false);
+        }
+    }
+
+    std::pair<iterator, bool> insert(value_type&& v) {
+        auto it = map_.find(v.first);
+        if (it == map_.end()) {
+            vec_.emplace_back(std::move(v));
+            return _post_insert();
+        } else {
+            return std::make_pair(it, false);
+        }
+    }
+
+    template<class P>
+    std::pair<iterator, bool> insert(P&& v) {
+        return emplace(std::forward<P>(v));
+    }
+
+    template<class InputIter>
+    void insert(InputIter first, InputIter last) {
+        for(; first != last; ++first) insert(*first);
+    }
+
+    void insert(std::initializer_list<value_type> ilist) {
+        for (const value_type& v: ilist) insert(v);
+    }
+
+private:
+    std::pair<iterator, bool> _post_insert() {
+        value_type& r = vec_.back();
+        map_.emplace_back(r.first, vec_.size() - 1);
+        return std::make_pair(--vec_.end(), true);
+    }
+
+}; // end class ordered_dict
+
+
+} // end namespace clue
+
+#endif

--- a/tests/test_ordered_dict.cpp
+++ b/tests/test_ordered_dict.cpp
@@ -44,6 +44,14 @@ void verify_odict(odict& d) {
     ASSERT_EQ(1, d_c.count("c"));
     ASSERT_EQ(0, d_c.count("x"));
 
+    ASSERT_EQ((entry{"a", 1}), d.at_pos(0));
+    ASSERT_EQ((entry{"b", 3}), d.at_pos(1));
+    ASSERT_EQ((entry{"c", 2}), d.at_pos(2));
+
+    ASSERT_EQ((entry{"a", 1}), d_c.at_pos(0));
+    ASSERT_EQ((entry{"b", 3}), d_c.at_pos(1));
+    ASSERT_EQ((entry{"c", 2}), d_c.at_pos(2));
+
     ASSERT_EQ((entry{"a", 1}), *d.find("a"));
     ASSERT_EQ((entry{"b", 3}), *d.find("b"));
     ASSERT_EQ((entry{"c", 2}), *d.find("c"));

--- a/tests/test_ordered_dict.cpp
+++ b/tests/test_ordered_dict.cpp
@@ -1,0 +1,244 @@
+#include <gtest/gtest.h>
+#include <clue/ordered_dict.hpp>
+#include <string>
+
+using namespace clue;
+
+using std::string;
+using odict = ordered_dict<string, int>;
+using entry = odict::value_type;
+
+TEST(OrderedDict, Empty) {
+    odict d;
+
+    ASSERT_TRUE(d.empty());
+    ASSERT_EQ(0, d.size());
+    ASSERT_TRUE(d.max_size() > 0);
+    ASSERT_TRUE(d.begin() == d.end());
+    ASSERT_TRUE(d.cbegin() == d.end());
+
+    ASSERT_EQ(d.end(), d.find("a"));
+    ASSERT_EQ(d.cend(), static_cast<const odict&>(d).find("a"));
+
+    ASSERT_TRUE(d == d);
+}
+
+void verify_odict(odict& d) {
+    const odict& d_c = d;
+
+    ASSERT_FALSE(d.empty());
+    ASSERT_EQ(3, d.size());
+
+    ASSERT_EQ(1, d.at("a"));
+    ASSERT_EQ(3, d.at("b"));
+    ASSERT_EQ(2, d.at("c"));
+    ASSERT_THROW(d.at("x"), std::out_of_range);
+
+    ASSERT_EQ(1, d_c.at("a"));
+    ASSERT_EQ(3, d_c.at("b"));
+    ASSERT_EQ(2, d_c.at("c"));
+    ASSERT_THROW(d_c.at("x"), std::out_of_range);
+
+    ASSERT_EQ(1, d_c.count("a"));
+    ASSERT_EQ(1, d_c.count("b"));
+    ASSERT_EQ(1, d_c.count("c"));
+    ASSERT_EQ(0, d_c.count("x"));
+
+    ASSERT_EQ((entry{"a", 1}), *d.find("a"));
+    ASSERT_EQ((entry{"b", 3}), *d.find("b"));
+    ASSERT_EQ((entry{"c", 2}), *d.find("c"));
+
+    ASSERT_EQ((entry{"a", 1}), *d_c.find("a"));
+    ASSERT_EQ((entry{"b", 3}), *d_c.find("b"));
+    ASSERT_EQ((entry{"c", 2}), *d_c.find("c"));
+
+    std::vector<entry> vref{{"a", 1}, {"b", 3}, {"c", 2}};
+
+    ASSERT_EQ(vref, std::vector<entry>(d_c.begin(), d_c.end()));
+    ASSERT_EQ(vref, std::vector<entry>(d.begin(), d.end()));
+    ASSERT_EQ(vref, std::vector<entry>(d.cbegin(), d.cend()));
+
+    ASSERT_TRUE(d_c == d_c);
+    ASSERT_FALSE(d != d_c);
+    ASSERT_FALSE(d_c == odict());
+}
+
+
+TEST(OrderedDict, Emplace) {
+    odict d;
+
+    auto r0 = d.emplace("a", 1);
+    auto r1 = d.emplace("b", 3);
+    auto r2 = d.emplace("c", 2);
+    auto r3 = d.emplace("a", 5);
+
+    ASSERT_TRUE(r0.second);
+    ASSERT_TRUE(r1.second);
+    ASSERT_TRUE(r2.second);
+    ASSERT_FALSE(r3.second);
+
+    verify_odict(d);
+}
+
+TEST(OrderedDict, TryEmplace) {
+    odict d;
+
+    auto r0 = d.try_emplace("a", 1);
+    auto r1 = d.try_emplace("b", 3);
+    auto r2 = d.try_emplace("c", 2);
+    auto r3 = d.try_emplace("a", 5);
+
+    ASSERT_TRUE(r0.second);
+    ASSERT_TRUE(r1.second);
+    ASSERT_TRUE(r2.second);
+    ASSERT_FALSE(r3.second);
+
+    verify_odict(d);
+}
+
+TEST(OrderedDict, InsertCopy) {
+    odict d;
+
+    entry e1{"a", 1};
+    entry e2{"b", 3};
+    entry e3{"c", 2};
+    entry e4{"a", 5};
+
+    auto r0 = d.insert(e1);
+    auto r1 = d.insert(e2);
+    auto r2 = d.insert(e3);
+    auto r3 = d.insert(e4);
+
+    ASSERT_TRUE(r0.second);
+    ASSERT_TRUE(r1.second);
+    ASSERT_TRUE(r2.second);
+    ASSERT_FALSE(r3.second);
+
+    verify_odict(d);
+}
+
+TEST(OrderedDict, InsertMove) {
+    odict d;
+
+    auto r0 = d.insert(entry{"a", 1});
+    auto r1 = d.insert(entry{"b", 3});
+    auto r2 = d.insert(entry{"c", 2});
+    auto r3 = d.insert(entry{"a", 5});
+
+    ASSERT_TRUE(r0.second);
+    ASSERT_TRUE(r1.second);
+    ASSERT_TRUE(r2.second);
+    ASSERT_FALSE(r3.second);
+
+    verify_odict(d);
+}
+
+TEST(OrderedDict, InsertRange) {
+    odict d;
+
+    std::vector<entry> src{{"a", 1}, {"b", 3}, {"c", 2}, {"a", 5}};
+    d.insert(src.begin(), src.end());
+
+    verify_odict(d);
+}
+
+TEST(OrderedDict, InsertInitList) {
+    odict d;
+    d.insert({ {"a", 1}, {"b", 3}, {"c", 2}, {"a", 5} });
+    verify_odict(d);
+}
+
+TEST(OrderedDict, ConstructFromRange) {
+    std::vector<entry> src{{"a", 1}, {"b", 3}, {"c", 2}, {"a", 5}};
+    odict d(src.begin(), src.end());
+    verify_odict(d);
+}
+
+TEST(OrderedDict, ConstructFromInitList) {
+    odict d{ entry{"a", 1}, entry{"b", 3}, entry{"c", 2}, entry{"a", 5} };
+    verify_odict(d);
+}
+
+TEST(OrderedDict, CopyConstruct) {
+    odict d{ entry{"a", 1}, entry{"b", 3}, entry{"c", 2} };
+    odict dc(d);
+    verify_odict(d);
+    verify_odict(dc);
+}
+
+TEST(OrderedDict, MoveConstruct) {
+    odict d{ entry{"a", 1}, entry{"b", 3}, entry{"c", 2} };
+    odict dm(std::move(d));
+
+    verify_odict(dm);
+
+    ASSERT_TRUE(d.empty());
+    ASSERT_TRUE(d.begin() == d.end());
+    ASSERT_TRUE(d.find("a") == d.end());
+}
+
+TEST(OrderedDict, CopyAssign) {
+    odict d{ entry{"a", 1}, entry{"b", 3}, entry{"c", 2} };
+    odict dc;
+    dc = d;
+    verify_odict(d);
+    verify_odict(dc);
+}
+
+TEST(OrderedDict, MoveAssign) {
+    odict d{ entry{"a", 1}, entry{"b", 3}, entry{"c", 2} };
+    odict dm;
+    dm = std::move(d);
+
+    verify_odict(dm);
+
+    ASSERT_TRUE(d.empty());
+    ASSERT_TRUE(d.begin() == d.end());
+    ASSERT_TRUE(d.find("a") == d.end());
+}
+
+TEST(OrderedDict, AssignFromInitList) {
+    odict d;
+    d = { entry{"a", 1}, entry{"b", 3}, entry{"c", 2} };
+    verify_odict(d);
+}
+
+TEST(OrderedDict, Swap) {
+    using std::swap;
+
+    odict d{ entry{"a", 1}, entry{"b", 3}, entry{"c", 2} };
+    odict dm;
+    swap(d, dm);
+
+    verify_odict(dm);
+
+    ASSERT_TRUE(d.empty());
+    ASSERT_TRUE(d.begin() == d.end());
+    ASSERT_TRUE(d.find("a") == d.end());
+}
+
+TEST(OrderedDict, Clear) {
+    odict d{ entry{"a", 1}, entry{"b", 3}, entry{"c", 2} };
+
+    verify_odict(d);
+    d.clear();
+
+    ASSERT_TRUE(d.empty());
+    ASSERT_TRUE(d.begin() == d.end());
+    ASSERT_TRUE(d.find("a") == d.end());
+}
+
+TEST(OrderedDict, SqBrackets) {
+    odict d;
+
+    d["a"] = 10;
+    d["b"] = 3;
+    d["c"] = 2;
+
+    ASSERT_EQ(10, d.at("a"));
+
+    string a = "a";
+    d[a] = 1;
+
+    verify_odict(d);
+}


### PR DESCRIPTION
This is an associative container class similar to ``std::unordered_map``, except that it will maintain the input order, like Python's [OrderedDict](https://docs.python.org/2/library/collections.html#collections.OrderedDict).